### PR TITLE
Return an error when syslog is configured on local datastore

### DIFF
--- a/Plugins/51 Syslog Name.ps1
+++ b/Plugins/51 Syslog Name.ps1
@@ -10,5 +10,6 @@ $PluginVersion = 1.1
 $SyslogServer ="syslogserver"
 # End of Settings
 
-@($VMH | Where-Object {$_.ExtensionData.Summary.Config.Product.Name -eq 'VMware ESXi'} | Select-Object Name,@{Name='SyslogServer';Expression = {($_ | Get-VMHostSysLogServer).Host}} | Where-Object {$_.SyslogServer -ne $syslogserver})
+# @($VMH | Where-Object {$_.ExtensionData.Summary.Config.Product.Name -eq 'VMware ESXi'} | Select-Object Name,@{Name='SyslogServer';Expression = {($_ | Get-VMHostSysLogServer).Host}} | Where-Object {$_.SyslogServer -ne $syslogserver})
+@($VMH | Where-Object {$_.ExtensionData.Summary.Config.Product.Name -eq 'VMware ESXi'} | Select-Object Name,@{Name='SyslogSetting';Expression = {(Get-VMHostAdvancedConfiguration -VMHost $_ -Name Syslog.Local.DatastorePath).Values| Where {$_ isnotnullempty}}})
 $PluginCategory = "vSphere"


### PR DESCRIPTION
Hello Alan, Jonathan,

I propose to change the code to check the “Syslog.Local.DatastorePath” if it is empty.

Best Regards
Denis
