### PR TITLE
19 Fix duplicate entrees when a single vm has multiple drives with low freespace

### DIFF
--- a/Plugins/19 Guests with less than X MB free.ps1
+++ b/Plugins/19 Guests with less than X MB free.ps1
@@ -16,10 +16,11 @@ ForEach ($VMdsk in $SortedVMs){
 			$Details | Add-Member -Name "Disk$($DiskNum)Capacity(MB)" -MemberType NoteProperty -Value ([math]::Round($disk.Capacity/ 1MB))
 			$Details | Add-Member -Name "Disk$($DiskNum)FreeSpace(MB)" -MemberType NoteProperty -Value ([math]::Round($disk.FreeSpace / 1MB))
 			$DiskNum++
-			$MyCollection += $Details
 			}
 	}
-	
+	if ($DiskNum -gt 0){
+		$MyCollection += $Details
+	}
 }
 $MyCollection
 


### PR DESCRIPTION
Fixed module 19 to handle multiple drives per vm that are low on freespace.

Before: [note the duplicate lines]
![vcheck_disk](https://f.cloud.github.com/assets/4061075/1091184/4b227572-1664-11e3-9db6-7e9366823dab.png)

After:
![vehck_after](https://f.cloud.github.com/assets/4061075/1091185/50240e64-1664-11e3-8709-1c356645fe6b.png)
