### PR TITLE
Update 81 LUN Paths Check.ps1

### DIFF
--- a/Plugins/81 LUN Paths Check.ps1
+++ b/Plugins/81 LUN Paths Check.ps1
@@ -24,7 +24,7 @@ foreach ($esxhost in ($HostsViews | where {$_.Runtime.ConnectionState -match "Co
 
 	#Create report for ESX host
 	foreach ($lun in $lun_array) {
-		if ($lun[1] -ne $RecLUNPaths) {
+		if ($lun[1] -ge $RecLUNPaths) {
 			#Write-Host "Alerting due to lack of paths (" $lun[1] "looking for" $RecLUNPaths "), for LUN: " $lun[0]
 			$myObj = "" | Select ESXHost, LUN , Paths
 			$myObj.ESXHost = $esxhost.Name


### PR DESCRIPTION
Changed $lun[1] -ne $RecLUNPaths to $lun[1] -ge $RecLUNPaths to reflect that having more than the recommended $number of paths is also good. Our environment has a mix of 2-4 paths depending on storage controller.
