### PR TITLE
46 - Update Missing ESX patches.ps1

### DIFF
--- a/Plugins/46 Missing ESX patches.ps1
+++ b/Plugins/46 Missing ESX patches.ps1
@@ -1,6 +1,12 @@
 # Start of Settings 
 # End of Settings 
 
+# Note: This plugin needs the vCenter Update Manager PowerCLI snap-in installed
+# https://communities.vmware.com/community/vmtn/automationtools/powercli/updatemanager
+# (Current version 5.1 locks up in powershell v3; use "-version 2" when launching.)
+
+$Results = @()
+
 If (Get-PSSnapin Vmware.VumAutomation -ErrorAction SilentlyContinue) {
 	foreach($esx in $VMH){
 		foreach($baseline in (Get-Compliance -Entity $esx -Detailed | where {$_.Status -eq "NotCompliant"})){


### PR DESCRIPTION
Cleared out $Results at start to avoid a previous module's data from being displayed if $Results isn't changed.

The missing updates plugin was displaying a previous plugin's data when Vmware.VumAutomation was not loading:
![image](https://f.cloud.github.com/assets/4061075/1110338/73222af6-1991-11e3-94e0-81a3a850d768.png)
