### PR TITLE
Update 81 LUN Paths Check.ps1

### DIFF
--- a/Plugins/81 LUN Paths Check.ps1
+++ b/Plugins/81 LUN Paths Check.ps1
@@ -24,7 +24,7 @@ foreach ($esxhost in ($HostsViews | where {$_.Runtime.ConnectionState -match "Co
 
 	#Create report for ESX host
 	foreach ($lun in $lun_array) {
-		if ($lun[1] -ge $RecLUNPaths) {
+		if ($lun[1] -lt $RecLUNPaths) {
 			#Write-Host "Alerting due to lack of paths (" $lun[1] "looking for" $RecLUNPaths "), for LUN: " $lun[0]
 			$myObj = "" | Select ESXHost, LUN , Paths
 			$myObj.ESXHost = $esxhost.Name


### PR DESCRIPTION
Edited -ge to -lt. Previously proposed fix inverted answer. $lun is precented in report if being less than the recommended number. In default means if there is less than 2 paths then it is an error. 2 or more is good.
