### PR TITLE
Update 19 Guests with less than X MB free.ps1

### DIFF
--- a/Plugins/19 Guests with less than X MB free.ps1
+++ b/Plugins/19 Guests with less than X MB free.ps1
@@ -1,6 +1,7 @@
 # Start of Settings 
 # VM Disk space left, set the amount you would like to report on
 $MBFree =1024
+$MBDiskMinSize = 1024
 # End of Settings
 
 $MyCollection = @()
@@ -11,7 +12,7 @@ ForEach ($VMdsk in $SortedVMs){
 	$DiskNum = 0
 	$Details | Add-Member -Name Name -Value $VMdsk.name -Membertype NoteProperty
 	Foreach ($disk in $VMdsk.Guest.Disk){
-		if (([math]::Round($disk.FreeSpace / 1MB)) -lt $MBFree){
+		if ((([math]::Round($disk.Capacity / 1MB)) -gt $MBDiskMinSize) -and (([math]::Round($disk.FreeSpace / 1MB)) -lt $MBFree)){
 			$Details | Add-Member -Name "Disk$($DiskNum)path" -MemberType NoteProperty -Value $Disk.DiskPath
 			$Details | Add-Member -Name "Disk$($DiskNum)Capacity(MB)" -MemberType NoteProperty -Value ([math]::Round($disk.Capacity/ 1MB))
 			$Details | Add-Member -Name "Disk$($DiskNum)FreeSpace(MB)" -MemberType NoteProperty -Value ([math]::Round($disk.FreeSpace / 1MB))


### PR DESCRIPTION
Added option to disregard small disks. Default set to not check disks less than 1024 MB as these will always pop in the original report. Checking if a disk that is less than 1024 MB has less free space than 1024 MB seems redundant.
