### PR TITLE
22 Checking VM Hardware Version: problem with v10 (ESXi 5.5)

### DIFF
--- a/Plugins/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Connection Plugin for vCenter.ps1
@@ -77,7 +77,7 @@ New-VIProperty -Name PercentFree -ObjectType Datastore -Value {
 New-VIProperty -Name "HWVersion" -ObjectType VirtualMachine -Value {
 	param($vm)
 
-	$vm.ExtensionData.Config.Version[5-6]
+	$vm.ExtensionData.Config.Version.Substring(4)
 } -BasedOnExtensionProperty "Config.Version" -Force | Out-Null
 
 Write-CustomOut "Collecting VM Objects"


### PR DESCRIPTION
Changed:

$vm.ExtensionData.Config.Version[5-6]

to:
$vm.ExtensionData.Config.Version.Substring(4)

https://github.com/alanrenouf/vCheck-vSphere/issues/65#issuecomment-26888052
