### PR TITLE
vCheck.ps1 - Settings Config - Show Plugin Name

### DIFF
--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -101,7 +101,11 @@ Function Invoke-Settings ($Filename, $GB) {
 	if (!(($OriginalLine +1) -eq $EndLine)) {
 		$Array = @()
 		$Line = $OriginalLine
-		Write-Host "`n"($filename.split("\")[-1]).split(".")[0]
+		$PluginName = (Get-PluginID $Filename).Title
+		If ($PluginName.EndsWith(".ps1",1)) {
+			$PluginName = ($PluginName.split("\")[-1]).split(".")[0]
+		}
+		Write-Host "`n$PluginName" -foreground $host.PrivateData.WarningForegroundColor -background $host.PrivateData.WarningBackgroundColor
 		do {
 			$Question = $file[$Line]
 			$Line ++
@@ -495,6 +499,7 @@ $TTRReport = @()
 $MyReport = Get-CustomHTML -Header "$Server vCheck"
 $MyReport += Get-CustomHeader0 ($Server)
 
+Write-Host "`nBegin Plugin Processing" -foreground $host.PrivateData.WarningForegroundColor -background $host.PrivateData.WarningBackgroundColor
 # Loop over all enabled plugins
 $p = 0 
 $Plugins | Foreach {


### PR DESCRIPTION
Adds the plugin name to the settings config making it much more clear
which plugin the settings you are configuring are for.

![image](https://f.cloud.github.com/assets/4913609/2340708/a9a58cfe-a4c8-11e3-9628-49c2b6be8e98.png)
