### PR TITLE
GlobalVariables additional documentation/notes

### DIFF
--- a/GlobalVariables.ps1
+++ b/GlobalVariables.ps1
@@ -13,9 +13,11 @@ $Server ="192.168.0.9"
 $SMTPSRV ="mysmtpserver.mydomain.local"
 # Please specify the email address who will send the vCheck report
 $EmailFrom ="me@mydomain.local"
-# Please specify the email address who will receive the vCheck report
+# Please specify the email address(es) who will receive the vCheck report
+# To specify multiple recipients, use the following format: "me@mydomain.local,me2@mydomain.local"
 $EmailTo ="me@mydomain.local"
-# Please specify the email address who will be CCd to receive the vCheck report
+# Please specify the email address(es) who will be CCd to receive the vCheck report
+# To specify multiple recipients, use the following format: "me@mydomain.local,me2@mydomain.local"
 $EmailCc =""
 # Please specify an email subject
 $EmailSubject="$Server vCheck Report"


### PR DESCRIPTION
When upgrading from vCheck 6.18 -> 6.20-alpha-1, email functionality was
changed slightly.  Previously, you could list multiple To addresses in
the format: "me@mydomain.local","me2@mydomain.local"

With the new changes this doesn't work.  Added notes to give a proper
example: "me@mydomain.local,me2@mydomain.local"
