### PR TITLE
Added CC to Email Msg Send - Fix Issue #160

### DIFF
--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -572,7 +572,7 @@ if ($SendEmail) {
 	Write-CustomOut $lang.emailSend
    $msg = New-Object System.Net.Mail.MailMessage ($EmailFrom,$EmailTo)
    # If CC address specified, add
-   If ($EmailCc -ne $null) {
+   If ($EmailCc -ne "") {
       $msg.CC.Add($EmailCc)
    }
    $msg.subject = $EmailSubject


### PR DESCRIPTION
Email was not being sent to CC recipient as expected.
Added check for CC, if exists add to $msg
