### PR TITLE
Plugin 103 - Fixed invalid chars in settings block

### DIFF
--- a/Plugins/103 VMs CPU MEM Add Hot Disabled.ps1
+++ b/Plugins/103 VMs CPU MEM Add Hot Disabled.ps1
@@ -1,4 +1,5 @@
-��# End of Settings
+# Start of Settings
+# End of Settings
 
 $ListCPUMemDisabled = @()
 


### PR DESCRIPTION
Error during config due to invalid chars - replaced with fresh settings block
