### PR TITLE
Report active hosts with disabled alarms

### DIFF
--- a/Plugins/16 Host Swapfile datastores.ps1
+++ b/Plugins/16 Host Swapfile datastores.ps1
@@ -6,12 +6,15 @@ foreach ($clusview in $clusviews) {
 	if ($clusview.ConfigurationEx.VmSwapPlacement -eq "hostLocal") {
 		$CluNodes = Get-VMHost -Location $clusview.name
 		foreach ($CluNode in $CluNodes) {
-			if ($CluNode.ExtensionData.Config.LocalSwapDatastore.Value) {
-				$Details = "" | Select-Object Cluster, Host, Message
-				$Details.cluster = $clusview.name
-				$Details.host = $CluNode.name
-				$Details.Message = "Swapfile location NOT SET"
-				$cluswap += $Details
+			if ($CluNode.VMSwapfileDatastore.Name -ne $null){}
+				else {	
+				if ($CluNode.ExtensionData.Config.LocalSwapDatastore.Value) {
+					$Details = "" | Select-Object Cluster, Host, Message
+					$Details.cluster = $clusview.name
+					$Details.host = $CluNode.name
+					$Details.Message = "Swapfile location NOT SET"
+					$cluswap += $Details
+				}	
 			}
 		}
 	}


### PR DESCRIPTION
Hello Alan,

I propose  a new report for the mentionned purpose.
## We have many vCenter and host and it's very important if we forgot to reactivate Alarm on host after maintenance mode.
# Start of Settings
# End of Settings

$hostsalarmstate = @()
foreach ($myhost in $VMH){

```
if ($myhost.ExtensionData.AlarmActionsEnabled -match "false" -and $myhost.ExtensionData.Runtime.InMaintenanceMode -match "True"){
        $Details = "" | Select-Object Object, Alarm, Status
        $Details.Object = $myhost.name
        $Details.Alarm = "AlarmActions"
        $Details.Status = $myhost.ExtensionData.AlarmActionsEnabled
        $hostsalarmstate += $Details
    }
}
```

$Result = @($hostsalarmstate |sort Object)
$Result

$Title = "Hosts with Alarm disabled"
$Header =  "Hosts with Alarms disabled : $(@($hostsalarmstate).Count)"
$Comments = "The following Hosts have Alarm disabled. This may impact the Alarming of your infrastrucure."
$Display = "Table"
$Author = "Denis Gauthier"
$PluginVersion = 1.1
$PluginCategory = "vSphere"

---

Thanks and Best Regards
Denis
