### PR TITLE
Fix Global Variables Self Destruct

### DIFF
--- a/GlobalVariables.ps1
+++ b/GlobalVariables.ps1
@@ -36,3 +36,5 @@ $TimeToRun = $true
 # Report an plugins that take longer than the following amount of seconds
 $PluginSeconds = 30
 # End of Settings
+
+# End of Global Variables


### PR DESCRIPTION
The setup/config/settings routine did not like the fact that the last line in the file was

```
# End of Settings
```

On first run, it appended an additional # End of Settings line, on the second run it errors and rewrites file incorrectly.

Simplest fix seemed to be to just add comment line at the end of the file
