### PR TITLE
Properly disposing of SMTP to prevent file lock

### DIFF
--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -613,6 +613,8 @@ if ($SendEmail) {
       $smtpClient.EnableSsl = $true
    }
    $smtpClient.Send($msg)
+   If ($SendAttachment) { $attachment.Dispose() }
+   $msg.Dispose()
 }
 
 # Run EndScript once everything else is complete


### PR DESCRIPTION
I noticed when sending email attachments that the SMTP client was at times leaving a lock on the file causing subsequent runs to fail (or sending the results of a previous run).
The included tweak will dispose of the email attachment as well as the message once it is sent.
