### PR TITLE
Update to Settings handling

### DIFF
--- a/GlobalVariables.ps1
+++ b/GlobalVariables.ps1
@@ -3,34 +3,34 @@
 
 
 # Set the following to true to enable the setup wizard for first time run
-$SetupWizard =$true
+$SetupWizard = $true
 
 
 # Start of Settings
 # Please Specify the IP address or Hostname of the server to connect to
-$Server ="192.168.0.9"
+$Server = "192.168.0.9"
+# Would you like the report displayed in the local browser once completed ?
+$DisplaytoScreen = $true
+# Use the following item to define if an email report should be sent once completed
+$SendEmail = $false
 # Please Specify the SMTP server address
-$SMTPSRV ="mysmtpserver.mydomain.local"
-# Please specify the email address who will send the vCheck report
-$EmailFrom ="me@mydomain.local"
-# Please specify the email address(es) who will receive the vCheck report (separate multiple addresses with comma)
-$EmailTo ="me@mydomain.local"
-# Please specify the email address(es) who will be CCd to receive the vCheck report (separate multiple addresses with comma)
-$EmailCc =""
-# Please specify an email subject
-$EmailSubject="$Server vCheck Report"
+$SMTPSRV = "mysmtpserver.mydomain.local"
 # Would you like to use SSL to send email?
 $EmailSSL = $false
+# Please specify the email address who will send the vCheck report
+$EmailFrom = "me@mydomain.local"
+# Please specify the email address(es) who will receive the vCheck report (separate multiple addresses with comma)
+$EmailTo = "me@mydomain.local"
+# Please specify the email address(es) who will be CCd to receive the vCheck report (separate multiple addresses with comma)
+$EmailCc = ""
+# Please specify an email subject
+$EmailSubject = "$Server vCheck Report"
 # Send the report by e-mail even if it is empty?
-$EmailReportEvenIfEmpty =$true
-# Would you like the report displayed in the local browser once completed ?
-$DisplaytoScreen =$True
-# Use the following item to define if an email report should be sent once completed
-$SendEmail =$true
+$EmailReportEvenIfEmpty = $true
 # If you would prefer the HTML file as an attachment then enable the following:
-$SendAttachment =$false
+$SendAttachment = $false
 # Set the style template to use.
-$Style ="VMware"
+$Style = "VMware"
 # Set the following setting to $true to see how long each Plugin takes to run as part of the report
 $TimeToRun = $true
 # Report an plugins that take longer than the following amount of seconds

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -111,13 +111,13 @@ Function Invoke-Settings ($Filename, $GB) {
 			$Line ++
 			$Split= ($file[$Line]).Split("=")
 			$Var = $Split[0]
-			$CurSet = $Split[1]
+			$CurSet = $Split[1].Trim()
 			
 			# Check if the current setting is in speech marks
 			$String = $false
 			if ($CurSet -match '"') {
 				$String = $true
-				$CurSet = $CurSet.Replace('"', '')
+				$CurSet = $CurSet.Replace('"', '').Trim()
 			}
 			$NewSet = Read-Host "$Question [$CurSet]"
 			If (-not $NewSet) {
@@ -125,10 +125,10 @@ Function Invoke-Settings ($Filename, $GB) {
 			}
 			If ($String) {
 				$Array += $Question
-				$Array += "$Var=`"$NewSet`""
+				$Array += "$Var= `"$NewSet`""
 			} Else {
 				$Array += $Question
-				$Array += "$Var=$NewSet"
+				$Array += "$Var= $NewSet"
 			}
 			$Line ++ 
 		} Until ( $Line -ge ($EndLine -1) )
@@ -138,7 +138,7 @@ Function Invoke-Settings ($Filename, $GB) {
 		$out = $File[0..($OriginalLine -1)]
 		$out += $array
 		$out += $File[$Endline..($file.count -1)]
-		if ($GB) { $out[$SetupLine] = '$SetupWizard =$False' }
+		if ($GB) { $out[$SetupLine] = '$SetupWizard = $False' }
 		$out | Out-File $Filename
 	}
 }

--- a/vCheckUtils.ps1
+++ b/vCheckUtils.ps1
@@ -409,7 +409,7 @@ Function Set-PluginSettings {
 			$Line ++
 			$Split= ($file[$Line]).Split("=")
 			$Var = $Split[0]
-			$CurSet = $Split[1]
+			$CurSet = $Split[1].Trim()
 			Foreach ($setting in $settings) {
 				If ($question -eq $setting.question) {	
 					$NewSet = $setting.var
@@ -421,7 +421,7 @@ Function Set-PluginSettings {
 				$String = $false
 				if ($CurSet -match '"') {
 					$String = $true
-					$CurSet = $CurSet.Replace('"', '')
+					$CurSet = $CurSet.Replace('"', '').Trim()
 				}
 				$NewSet = Read-Host "$Question [$CurSet]"
 				If (-not $NewSet) {
@@ -432,7 +432,7 @@ Function Set-PluginSettings {
 				}
 			}
 			$Array += $Question
-			$Array += "$Var=$NewSet"
+			$Array += "$Var= $NewSet"
 			$Line ++ 
 		} Until ( $Line -ge ($EndLine -1) )
 		$Array += "# End of Settings"
@@ -444,7 +444,7 @@ Function Set-PluginSettings {
 		If ($GB) {
 			$Setup = ($file | Select-String -Pattern '# Set the following to true to enable the setup wizard for first time run').LineNumber
 			$SetupLine = $Setup ++
-			$out[$SetupLine] = '$SetupWizard =$False'
+			$out[$SetupLine] = '$SetupWizard = $False'
 		}
 		$out | Out-File $filename
 	}


### PR DESCRIPTION
Two simple changes here
1) Reordered the settings in GlobalVariables for better flow. Changed default to display in browser only to make it easy for first run - only vCenter server address needed to run by default.

2) Fixed spacing on settings write after config (or import). Previously some settings were getting written back incorrectly.
Example:
Original variable line

```
$variable = "value"
$variable = value
```

Rewritten after config (or import)

```
$variable =" value"
$variable =value
```

Now will rewrite properly after config (or import)

```
$variable = "value"
$variable = value
```
