### PR TITLE
Fixes #246

### DIFF
--- a/Plugins/20 Cluster/71 Capacity Planning.ps1
+++ b/Plugins/20 Cluster/71 Capacity Planning.ps1
@@ -16,7 +16,7 @@ foreach ($cluv in ($clusviews | Sort Name)) {
 			$DasRealMemCapacity = $cluv.Summary.EffectiveMemory * $limitResourceMEMClusNonHA
 		}
 		
-		$cluvmlist = $VM | where { $cluv.Host -contains $_.Host.Id  }
+		$cluvmlist = $VM | where { $cluv.Host -contains $_.VMHost.Id  }
 		
 		#CPU
 			$CluCpuUsage = (get-view $cluv.ResourcePool).Summary.runtime.cpu.OverallUsage


### PR DESCRIPTION
Update to plugin 71 Capacity Planning

'Host' property of Virtual Machine object replaced with 'VMHost' to avoid warning message
