### PR TITLE
New plugin combines/replaces 05, 06, and 117

### DIFF
--- a/Plugins/30 Host/83 Hosts not Connected or Alarms Disabled.ps1
+++ b/Plugins/30 Host/83 Hosts not Connected or Alarms Disabled.ps1
@@ -12,4 +12,8 @@ $Author = "Chris Monahan"
 $PluginVersion = 1.0
 $PluginCategory = "vSphere"
 
-# Combines/replaces two plugins, "05 Hosts in Maintenance mode.ps1" and "117 Hosts with Alarm disabled.ps1".
+<# 
+  Essentially a hosts not happy report.
+  Combines/replaces three plugins, "05 Hosts in Maintenance mode.ps1", "06 Hosts not responding or Disconnected.ps1" and "117 Hosts with Alarm disabled.ps1".
+  It's useful to have host status and alarm reporting status close instead of different areas of the report.
+#>


### PR DESCRIPTION
Essentially a hosts not happy report.

Combines/replaces three plugins, "05 Hosts in Maintenance mode.ps1", "06 Hosts not responding or Disconnected.ps1" and "117 Hosts with Alarm disabled.ps1".

It's useful to have host status and alarm reporting status close instead of different areas of the report.  In particular hosts that are in service (connected), but have alarms disabled.  The alarms probably should be enabled.

![screenshot](https://cloud.githubusercontent.com/assets/5665684/4493089/a29bee8e-4a46-11e4-93e2-27a2e90f9ee8.jpeg)
