### PR TITLE
Consolidated two plugins- "65 Snapshots Created" and "63 Snapshots Removed" into "67 Snapshot Activity"

### DIFF
--- a/Plugins/60 VM/67 Snapshot Activity.ps1
+++ b/Plugins/60 VM/67 Snapshot Activity.ps1
@@ -1,0 +1,19 @@
+﻿# Start of Settings
+# Set the number of days to show Snapshots for
+$VMsNewRemovedAge = 5
+# User exception for Snapshot removed
+$snapshotUserException = "s-veeam"
+# End of Settings
+
+Get-VIEventPlus -Start ((get-date).adddays(- $VMsNewRemovedAge)) -EventType "TaskEvent" | ? { $_.FullFormattedMessage -match "snapshot" -and $_.userName -notmatch $snapshotUserException } | Select @{ N = "Created Time"; E = { ($_.createdTime).ToLocalTime() } }, @{ N = "User"; E = { $_.userName } }, @{ N = "VM Name"; E = { $_.vm.name } }, @{ N = "Description"; E = { $_.FullFormattedMessage } } | sort "VM Name", "Created Time"
+
+$Title = "Snapshot activity"
+$Header = "Snapshot activity (Last $VMsNewRemovedAge Day(s)) (with user exception $snapshotUserException)"
+$Comments = ""
+$Display = "Table"
+$Author = "Chris Monahan, but is a minor mod of two plugins by Raphael Schitz and Frederic Martin"
+$PluginVersion = 1.0
+$PluginCategory = "vSphere"
+
+# This is a consolidation of "65 Snapshot Created.ps1" and "63 Snapshot Removed.ps1", both both Raphael Schitz and Frederic Martin.
+# Shows snapshot activity by listing any task with the word "snapshot" in it, sorting by VM name then time of task creation.


### PR DESCRIPTION
This one shows all snapshot activity sorted by VM name then task creation time.
