### PR TITLE
Change job plugin paths routine in vCheck.ps1 so it still works with PowerShell 2.0

### DIFF
--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -564,7 +564,7 @@ if ($job) {
       foreach ($PluginPath in ($jobConfig.vCheck.plugins.path -split ";")) {
          if (Test-Path $PluginPath) {
             $PluginPaths += (Get-Item $PluginPath).Fullname
-            $PluginPaths += Get-Childitem $PluginPath -Directory -recurse | Select -expandproperty FullName
+            $PluginPaths += Get-Childitem $PluginPath -recurse | ?{ $_.PSIsContainer } | Select -expandproperty FullName
          }
          else {      
             $PluginPaths += $ScriptPath + "\Plugins"


### PR DESCRIPTION
Change job plugin paths routine so it still works with PowerShell 2.0
I raised issue #306 to get someone else to fix this but I figured out how to do this myself (I think). Any suggestions you might have are welcome.