### PR TITLE
Added plugin settings descriptions

### DIFF
--- a/Plugins/20 Cluster/10 HA Configuration Issues.ps1
+++ b/Plugins/20 Cluster/10 HA Configuration Issues.ps1
@@ -1,4 +1,5 @@
 # Start of Settings
+# HA Configuration Issues, do not report on any Clusters that are defined here
 $ClustersDoNotInclude = "Example_Cluster_*|Test_Cluster_*"
 # End of Settings
 

--- a/Plugins/20 Cluster/55 Clusters with DRS Disabled.ps1
+++ b/Plugins/20 Cluster/55 Clusters with DRS Disabled.ps1
@@ -1,4 +1,5 @@
 # Start of Settings
+# Clusters with DRS Disabled, do not report on any Clusters that are defined here
 $ClustersDoNotInclude = "VM1_*|VM2_*"
 # End of Settings
  


### PR DESCRIPTION
Not having a plugin settings description causes the following error when exporting and importing settings:
```
You cannot call a method on a null-valued expression.
At E:\scripts\vCheck\vCheck.ps1:152 char:28
+             $CurSet = $Split[1].Trim <<<< ()
    + CategoryInfo          : InvalidOperation: (Trim:String) [], RuntimeExcep
   tion
    + FullyQualifiedErrorId : InvokeMethodOnNull
```
Added missing descriptions to 'HA Configuration Issues' and 'Clusters with DRS Disabled' plugins.