### PR TITLE
Added SMTP non-standard port support

### DIFF
--- a/GlobalVariables.ps1
+++ b/GlobalVariables.ps1
@@ -15,6 +15,8 @@ $DisplaytoScreen = $true
 $SendEmail = $false
 # Please Specify the SMTP server address
 $SMTPSRV = "mysmtpserver.mydomain.local"
+# Please Specify the SMTP server port
+$SMTPPORT = 25
 # Would you like to use SSL to send email?
 $EmailSSL = $false
 # Please specify the email address who will send the vCheck report

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -775,6 +775,7 @@ if ($SendEmail) {
    # Send the email
    $smtpClient = New-Object System.Net.Mail.SmtpClient
    $smtpClient.Host = $SMTPSRV
+   $smtpClient.Port = $SMTPPORT
    if ($EmailSSL -eq $true) {
       $smtpClient.EnableSsl = $true
    }


### PR DESCRIPTION
Raised issue #312 to address a missing functionality to specify a non default SMTP port. Now fixed with 2 simple lines of code. :smile: 