### PR TITLE
Exclude files in plugins dir

### DIFF
--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -598,7 +598,7 @@ if ($job) {
 else {
 	$ToNatural = { [regex]::Replace($_, '\d+', { $args[0].Value.PadLeft(20) }) }
 	$vCheckPlugins = @(Get-ChildItem -Path $PluginsFolder -filter "*.ps1" -Recurse | where {$_.Directory -match "initialize"} | Sort $ToNatural)
-	$PluginsSubFolder = Get-ChildItem -Path $PluginsFolder | where {($_.Name -notmatch "initialize") -and ($_.Name -notmatch "finish")}
+	$PluginsSubFolder = Get-ChildItem -Path $PluginsFolder | where {($_.PSIsContainer) -and ($_.Name -notmatch "initialize") -and ($_.Name -notmatch "finish")}
 	$vCheckPlugins += $PluginsSubFolder | % {Get-ChildItem -Path $_.FullName -filter "*.ps1" | Sort $ToNatural}
 	$vCheckPlugins += Get-ChildItem -Path $PluginsFolder -filter "*.ps1" -Recurse | where {$_.Directory -match "finish"} | Sort $ToNatural
 	$GlobalVariables = $ScriptPath + "\GlobalVariables.ps1"


### PR DESCRIPTION
Where it gets the subfolders of the `.\Plugins\` folder, it was finding both files and folders, then later, it tried to invoke them (I found this because I had a file `.\Plugins\backup.zip` and wondered why every time I ran vCheck, the zip file opened!). My understanding it that now, all plugins should be stored in subfolders, i.e. `.\Plugins\subfolder\plugin.ps1`, any files in `.\Plugins` shuold be ignored. This change accomplishes that.

(This is the first time I've used GitHub, so please let me know if I've done anything wrong :relaxed:)