### PR TITLE
Implemented $EmailReportEvenIfEmpty and $DisplayReportEvenIfEmpty

### DIFF
--- a/GlobalVariables.ps1
+++ b/GlobalVariables.ps1
@@ -11,6 +11,8 @@ $SetupWizard = $true
 $Server = "192.168.0.9"
 # Would you like the report displayed in the local browser once completed ?
 $DisplaytoScreen = $true
+# Display the report even if it is empty?
+$DisplayReportEvenIfEmpty = $true
 # Use the following item to define if an email report should be sent once completed
 $SendEmail = $false
 # Please Specify the SMTP server address (and optional port) [servername(:port)]

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -701,9 +701,11 @@ if ($TimeToRun) {
 #                                    Output                                    #
 ################################################################################
 # Loop over plugin results and generate HTML from style
+$emptyReport = $true
 $p=1
 Foreach ( $pr in $PluginResult) {
 	If ($pr.Details) {
+		$emptyReport = $false
 		switch ($pr.Display) {
 			"List"  { $pr.Details = Get-HTMLList $pr.Details }
 			"Table" { $pr.Details = Get-HTMLTable $pr.Details $pr.TableFormat }
@@ -737,13 +739,13 @@ Foreach ($cid in $global:ReportResources.Keys) {
 $embedReport | Out-File -encoding ASCII -filepath $Filename
 
 # Display to screen
-if ($DisplayToScreen) {
+if ($DisplayToScreen -and (!($emptyReport -and !$DisplayReportEvenIfEmpty))) {
 	Write-CustomOut $lang.HTMLdisp  
 	Invoke-Item $Filename
 }
 
 # Generate email
-if ($SendEmail) {
+if ($SendEmail -and (!($emptyReport -and !$EmailReportEvenIfEmpty))) {
 	Write-CustomOut $lang.emailSend
    $msg = New-Object System.Net.Mail.MailMessage ($EmailFrom,$EmailTo)
    # If CC address specified, add


### PR DESCRIPTION
The setting for `$EmailReportEvenIfEmpty` already existed, but wasn't
implemented in `vCheck.ps1` (see issue #299). This commit implements that functionality, as
well as adding a new setting `$DisplayReportEvenIfEmpty`