### PR TITLE
Update 34 Number of VMs per Datastore.ps1

### DIFF
--- a/Plugins/40 Datastore/34 Number of VMs per Datastore.ps1
+++ b/Plugins/40 Datastore/34 Number of VMs per Datastore.ps1
@@ -1,12 +1,13 @@
 # Start of Settings 
 # Max number of VMs per Datastore
 $NumVMsPerDatastore = 5
+$Excluded = "ExcludeMe"
 # End of Settings
 
 # Changelog
 ## 1.1 : Using managed objects collections in order to avoid using Get-VM cmdlet for performance matter
 
-$Result = @($StorageViews | Select Name, @{N="NumVM";E={($_.vm).Count}} | Where { $_.NumVM -gt $NumVMsPerDatastore} | Sort NumVM -Descending)
+$Result = @($StorageViews | Where-Object { $_.Name -notmatch $Excluded } | Select Name, @{N="NumVM";E={($_.vm).Count}} | Where { $_.NumVM -gt $NumVMsPerDatastore} | Sort NumVM -Descending)
 $Result
 
 $Title = "Number of VMs per Datastore"


### PR DESCRIPTION
Allows filtering of datastores from the query.  Most of our datastores are 4TB fibre channel LUNs, but we have one Tintri storage device that has 474 VMs on it.  That number goes way beyond the 35 VM limit we put in the report for the FC LUNs.