### PR TITLE
Update 105 Host Profile Compliance.ps1 - for array add failure on 29 if only one conforming host is found in a cluster

### DIFF
--- a/Plugins/30 Host/105 Host Profile Compliance.ps1
+++ b/Plugins/30 Host/105 Host Profile Compliance.ps1
@@ -22,9 +22,9 @@ foreach ($Profile in $HostProfiles) {
          $Failures = $Profile | Test-VMHostProfileCompliance -UseCache 
 
          # Find all Hosts with HP Applied and status
-         $VMHosts = $VMH | Where {(($Profile.ExtensionData.entity | Where {$_.type -eq "HostSystem" } | Select @{n="Id";e={"HostSystem-{0}" -f $_.Value}}) | Select -expandProperty Id) -contains $_.Id} 
+         $VMHosts = @($VMH | Where {(($Profile.ExtensionData.entity | Where {$_.type -eq "HostSystem" } | Select @{n="Id";e={"HostSystem-{0}" -f $_.Value}}) | Select -expandProperty Id) -contains $_.Id}) 
          # Filter out those with failures and select required columns
-         $VMHosts = $VMHosts | where {($failures | Select -expandproperty VMHostID) -notcontains $_.id} | Select @{Name="VMHostProfile";Expression={$Profile.Name}}, @{Name="Host";Expression={$_.Name}}, @{Name="Compliant";Expression={$true}}, @{Name="Failures";Expression={"None"}} 
+         $VMHosts = @($VMHosts | where {($failures | Select -expandproperty VMHostID) -notcontains $_.id} | Select @{Name="VMHostProfile";Expression={$Profile.Name}}, @{Name="Host";Expression={$_.Name}}, @{Name="Compliant";Expression={$true}}, @{Name="Failures";Expression={"None"}}) 
          # Add in the failures
          $VMHosts += ($Failures | Select VMHostProfile, @{Name='Host';Expression={$_.vmhost.name}}, @{Name='Compliant';Expression={$false}}, @{Name="Failures";Expression={($_.IncomplianceElementList | Select -expandproperty Description) -join "<br />"}})
          


### PR DESCRIPTION
Minor change to lines 25 and 27. If only one host comes up as conforming to a host profile in a cluster the $VMHosts variable  does not return as an array when the failures are added in line 29. These are then dropped from the report. By forcing the assignment to an array in lines 25 and 27 the add will always work.