### PR TITLE
Shared disks between VMs

### DIFF
--- a/Plugins/60 VM/120 Multi-writer.ps1
+++ b/Plugins/60 VM/120 Multi-writer.ps1
@@ -1,0 +1,21 @@
+# Start of Settings
+# End of Settings
+
+# Changelog
+## 1.0 : Initial Version
+
+# Multi-writer parameter
+
+$Result = @(ForEach ($vm in (Get-View -ViewType VirtualMachine -Property Name,Config.ExtraConfig -Filter @{"Config.Template"="False"})){
+    $vm.Config.ExtraConfig | Where {$_.Key -like "scsi*sharing"} |
+    Select @{N="VM";E={$vm.Name}},Key,Value
+})
+$Result
+
+$Title = "Multi-writer"
+$Header = "Multi-writer: $(@($Result).Count)"
+$Comments = "The following VMs have multi-writer parameter. A problem will occur in case of svMotion without reconfiguration of the applications which are using these virtual disks and also change of the VM configuration concerned. More information <a href='http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1034165'>here</a>."
+$Display = "Table"
+$Author = "Petar Enchev, Luc Dekens"
+$PluginVersion = 1.0
+$PluginCategory = "vSphere"

--- a/Plugins/60 VM/120 Multi-writer.ps1
+++ b/Plugins/60 VM/120 Multi-writer.ps1
@@ -6,7 +6,7 @@
 
 # Multi-writer parameter
 
-$Result = @(ForEach ($vm in (Get-View -ViewType VirtualMachine -Property Name,Config.ExtraConfig -Filter @{"Config.Template"="False"})){
+$Result = @(ForEach ($vm in $FullVM){
     $vm.Config.ExtraConfig | Where {$_.Key -like "scsi*sharing"} |
     Select @{N="VM";E={$vm.Name}},Key,Value
 })

--- a/Plugins/60 VM/121 BusSharingMode - Physical and Virtual.ps1
+++ b/Plugins/60 VM/121 BusSharingMode - Physical and Virtual.ps1
@@ -5,7 +5,7 @@
 ## 1.0 : Initial Version
 
 # BusSharingMode - Physical and Virtual
-$Result = @(ForEach ($vm in (Get-View -ViewType VirtualMachine -Property Name,Config.Hardware.Device -Filter @{"Config.Template"="False"})){
+$Result = @(ForEach ($vm in $FullVM){
     $scsi = $vm.Config.Hardware.Device | where {$_ -is [VMware.Vim.VirtualSCSIController] -and ($_.SharedBus -eq "physicalSharing" -or $_.SharedBus -eq "virtualSharing")}
     if ($scsi){
         $scsi | Select @{N="VM";E={$vm.Name}},

--- a/Plugins/60 VM/121 BusSharingMode - Physical and Virtual.ps1
+++ b/Plugins/60 VM/121 BusSharingMode - Physical and Virtual.ps1
@@ -1,0 +1,24 @@
+# Start of Settings
+# End of Settings
+
+# Changelog
+## 1.0 : Initial Version
+
+# BusSharingMode - Physical and Virtual
+$Result = @(ForEach ($vm in (Get-View -ViewType VirtualMachine -Property Name,Config.Hardware.Device -Filter @{"Config.Template"="False"})){
+    $scsi = $vm.Config.Hardware.Device | where {$_ -is [VMware.Vim.VirtualSCSIController] -and ($_.SharedBus -eq "physicalSharing" -or $_.SharedBus -eq "virtualSharing")}
+    if ($scsi){
+        $scsi | Select @{N="VM";E={$vm.Name}},
+            @{N="Controller";E={$_.DeviceInfo.Label}},
+            @{N="BusSharingMode";E={$_.SharedBus}}
+    }
+})
+$Result
+
+$Title = "BusSharingMode - Physical and Virtual"
+$Header = "BusSharingMode - Physical and Virtual: $(@($Result).Count)"
+$Comments = "The following VMs have physical and/or virtual bus sharing. A problem will occur in case of svMotion without reconfiguration of the applications which are using these virtual disks and also change of the VM configuration concerned."
+$Display = "Table"
+$Author = "Petar Enchev, Luc Dekens"
+$PluginVersion = 1.0
+$PluginCategory = "vSphere"


### PR DESCRIPTION
These plugins check if you have shared disks between two or more VMs. In most cases this is a problem because you cannot svMotion the VMs properly and that is why you have to have a special procedure.