### PR TITLE
Add filter for plugin 54

### DIFF
--- a/Plugins/60 VM/54 Virtual Machines with incorrect OS Configuration.ps1
+++ b/Plugins/60 VM/54 Virtual Machines with incorrect OS Configuration.ps1
@@ -1,7 +1,9 @@
 # Start of Settings
+# VMs with incorrect OS Configuration, do not report on any VMs who are defined here
+$VMTDoNotInclude = "VM1_*|VM2_*"
 # End of Settings
  
-$Result = @( $FullVM |`
+$Result = @( $FullVM | Where {$_.Name -notmatch $VMTDoNotInclude} |`
   Where-Object {$_.Guest.GuestId -and $_.Guest.GuestId -ne $_.Config.GuestId} | `
   Select-Object -Property Name,@{N="GuestId";E={$_.Guest.GuestId}},
     @{N="Installed Guest OS";E={$_.Guest.GuestFullName}},
@@ -15,5 +17,5 @@ $Header = "Virtual machines with incorrect OS configuration : $(@($Result).Count
 $Comments = "The following virtual machines have an installed OS that is different from the configured OS. This can impact the performance of the virtual machine."
 $Display = "Table"
 $Author = "Robert van den Nieuwendijk"
-$PluginVersion = 1.1
+$PluginVersion = 1.2
 $PluginCategory = "vSphere"


### PR DESCRIPTION
For some of the appliances is not possible to select an OS from the
dropdown menu.
That is why I added filter for "54 Virtual Machines with incorrect OS
Configuration".