### PR TITLE
Update 70 Cluster Node Version.ps1

### DIFF
--- a/Plugins/20 Cluster/70 Cluster Node Version.ps1
+++ b/Plugins/20 Cluster/70 Cluster Node Version.ps1
@@ -3,7 +3,7 @@
 
 $HostsVer = @()
 foreach ($clusview in $clusviews) {
-	$HostsVerMiss = $HostsViews | ?{ $_.Parent -match $clusview.MoRef} | select @{N="FullName";E={$_.Config.Product.FullName}} -Unique
+	$HostsVerMiss = $HostsViews | ?{ $_.Parent -match "^$($clusview.MoRef)$"} | select @{N="FullName";E={$_.Config.Product.FullName}} -Unique
 	if (($HostsVerMiss | Measure-Object).Count -gt 1) {
 		$allVer = ""
 		foreach ($Ver in $HostsVerMiss) { $allVer = $allVer + $Ver.FullName + ";" }


### PR DESCRIPTION
Update the match string to use an exact match.

Avoids that for example ClusterComputeResource-domain-c5 and ClusterComputeResource-domain-c5865 would match, and give an incorrect result.