### PR TITLE
NonPersistent Disks Exclude VMs

### DIFF
--- a/Plugins/60 VM/122 NonPersistent Disks.ps1
+++ b/Plugins/60 VM/122 NonPersistent Disks.ps1
@@ -1,4 +1,6 @@
 # Start of Settings
+# Exclude all desktop virtual machines
+$NPExcludeVM = "^DV-|^MLB-"
 # End of Settings
 
 # Changelog
@@ -6,20 +8,20 @@
 
 # NonPersistent Disks
 $diskModes = [VMware.Vim.VirtualDiskMode]::independent_nonpersistent,[VMware.Vim.VirtualDiskMode]::nonpersistent
-$Result = @(ForEach($vm in $FullVM){
-  $vm.Config.Hardware.Device |
-  Where {$_ -is [VMware.Vim.VirtualDisk] -and $diskModes -contains $_.Backing.DiskMode} |
-  Select @{N="VM";E={$vm.Name}},
-    @{N="Disk";E={$_.DeviceInfo.Label}},
-    @{N="Mode";E={$_.Backing.DiskMode}},
-    @{N="CapacityGB";E={$_.capacityInKB/1MB}},
-    @{N="Filename";E={$_.Backing.FileName}}
+$Result = @(ForEach($vm in $FullVM | Where {$_.Name -notmatch $NPExcludeVM}){
+	$vm.Config.Hardware.Device |
+	Where {$_ -is [VMware.Vim.VirtualDisk] -and $diskModes -contains $_.Backing.DiskMode} |
+	Select @{N="VM";E={$vm.Name}},
+		@{N="Disk";E={$_.DeviceInfo.Label}},
+		@{N="Mode";E={$_.Backing.DiskMode}},
+		@{N="CapacityGB";E={$_.capacityInKB/1MB}},
+		@{N="Filename";E={$_.Backing.FileName}}
 })
 $Result
 
 $Title = "NonPersistent Disks"
 $Header = "NonPersistent Disks: $(@($Result).Count)"
-$Comments = "The following VMs have disks in NonPersistent mode. A problem will occur in case of svMotion without reconfiguration of these virtual disks."
+$Comments = "The following server VMs have disks in NonPersistent mode (excludes all desktop VMs). A problem will occur in case of svMotion without reconfiguration of these virtual disks."
 $Display = "Table"
 $Author = "Petar Enchev, Luc Dekens"
 $PluginVersion = 1.0


### PR DESCRIPTION
Adds the ability to exclude VMs (by name) from the results of this plug-in.
MasterChiefJon
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
# On branch master
# Changes to be committed:
#	modified:   Plugins/60 VM/122 NonPersistent Disks.ps1
#