### PR TITLE
Fix #385

### DIFF
--- a/EndScript .ps1
+++ b/EndScript .ps1
@@ -1,1 +1,0 @@
-# Everything in this script will run at the end of vCheck

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -59,7 +59,7 @@ param (
 	[Switch]$config,
 
 	[ValidateScript({ Test-Path $_ -PathType 'Container' })]
-	[string]$Outputpath,
+	[string]$Outputpath=$Env:TEMP,
 
 	[ValidateScript({ Test-Path $_ -PathType 'Leaf' })]
 	[string]$job
@@ -818,15 +818,9 @@ Foreach ($pr in $PluginResult) {
 # Run Style replacement
 $MyReport = Get-ReportHTML
 
-# Set the output filename - if one is specified use it, otherwise just use temp
-if ($Outputpath) {
-	$DateHTML = Get-Date -Format "yyyyMMddHH"
-	$ArchiveFilePath = $Outputpath + "\Archives\" + $VIServer
-	if (-not (Test-Path -PathType Container $ArchiveFilePath)) { New-Item $ArchiveFilePath -type directory | Out-Null }
-	$Filename = $ArchiveFilePath + "\" + $VIServer + "_vCheck_" + $DateHTML + ".htm"
-} else {
-	$Filename = $Env:TEMP + "\" + $Server + "_vCheck_" + $Date.Day + "-" + $Date.Month + "-" + $Date.Year + ".htm"
-}
+# Set the output filename 
+if (-not (Test-Path -PathType Container $Outputpath)) { New-Item $Outputpath -type directory | Out-Null }
+$Filename = ("{0}\{1}_vCheck_{2}.htm" -f $Outputpath, $Server, (Get-Date -Format "yyyyMMdd_HHmm"))
 
 # Always generate the report with embedded images
 $embedReport = $MyReport


### PR DESCRIPTION
If $Outputpath is specified, we should use this path. 

Changed the default to $env:temp to simplify the code a little. Set date format to ISO8601 as well.