### PR TITLE
Check if PowerCLI module is already added and ignore unsupported ioctl

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -50,9 +50,11 @@ else
 # Path to credentials file which is automatically created if needed
 $Credfile = $ScriptPath + "\Windowscreds.xml"
 
-# Adding PowerCLI core snapin
-if (!(get-pssnapin -name VMware.VimAutomation.Core -erroraction silentlycontinue)) {
-	add-pssnapin VMware.VimAutomation.Core
+# Adding PowerCLI core snapin, also check if powerCLI module is alsready added
+if (!(get-module -name VMware.VimAutomation.Core -erroraction silentlycontinue)) {
+	if (!(get-pssnapin -name VMware.VimAutomation.Core -erroraction silentlycontinue)) {
+		add-pssnapin VMware.VimAutomation.Core -erroraction silentlycontinue
+	}
 }
 
 $OpenConnection = $global:DefaultVIServers | where { $_.Name -eq $VIServer }

--- a/Plugins/30 Host/44 VMKernel Warnings.ps1
+++ b/Plugins/30 Host/44 VMKernel Warnings.ps1
@@ -28,7 +28,7 @@ foreach ($VMHost in ($HostsViews)){
 			$VMKernelWarnings += $VMKernelWarning | Sort-Object -Property Length -Unique |select VMHost, Message, KBSearch, Google
 		}	
 	} else {
-		$Warnings = (Get-Log -VMHost ($VMHost.Name) -Key vmkernel -ErrorAction SilentlyContinue).Entries | where {$_ -match "warning"}
+		$Warnings = (Get-Log -VMHost ($VMHost.Name) -Key vmkernel -ErrorAction SilentlyContinue).Entries | where {$_ -match "warning" -and $_ -notmatch "unsupported ioctl"}
 		if ($Warnings -ne $null) {
 			$VMKernelWarning = @()
 			$Warnings | Foreach {


### PR DESCRIPTION
As I kept getting errors I added a check if the module was already added: (PowerCLI 6)

add-pssnapin : An item with the same key has already been added.
At C:\vCheck\vCheck-DG\Plugins\00 Initialize\00 Connection Plugin for vCenter.p
s1:55 char:2
+     add-pssnapin VMware.VimAutomation.Core
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Add-PSSnapin], ArgumentExcept
   ion
    + FullyQualifiedErrorId : System.ArgumentException,Microsoft.PowerShell.Co
   mmands.AddPSSnapinCommand

I added this: if (!(get-pssnapin -name VMware.VimAutomation.Core -erroraction silentlycontinue)) {

which resolved the errors. Also added the  -and $_ -notmatch "unsupported ioctl" , see https://github.com/alanrenouf/vCheck-vSphere/issues/397 , code by https://github.com/randy16randy

Grtz

Willem