### PR TITLE
 Check if PowerCLI module is already added

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -50,9 +50,11 @@ else
 # Path to credentials file which is automatically created if needed
 $Credfile = $ScriptPath + "\Windowscreds.xml"
 
-# Adding PowerCLI core snapin
-if (!(get-pssnapin -name VMware.VimAutomation.Core -erroraction silentlycontinue)) {
-	add-pssnapin VMware.VimAutomation.Core
+# Adding PowerCLI core snapin, also check if powerCLI module is alsready added
+if (!(get-module -name VMware.VimAutomation.Core -erroraction silentlycontinue)) {
+	if (!(get-pssnapin -name VMware.VimAutomation.Core -erroraction silentlycontinue)) {
+		add-pssnapin VMware.VimAutomation.Core -erroraction silentlycontinue
+	}
 }
 
 $OpenConnection = $global:DefaultVIServers | where { $_.Name -eq $VIServer }


### PR DESCRIPTION
As requested, pull request for the dev branch (sorry, should have done this the first time)
if (!(get-module -name VMware.VimAutomation.Core -erroraction
silentlycontinue)) added to 00 Connection Plugin for vCenter.ps1 