### PR TITLE
Create tbody section in table including Expandable/Collapsable Blocks

### DIFF
--- a/Plugins/40 Datastore/333 Disk Utilization DataStore Cluster and Datastore.ps1
+++ b/Plugins/40 Datastore/333 Disk Utilization DataStore Cluster and Datastore.ps1
@@ -1,0 +1,70 @@
+# Start of Settings 
+# Set the warning threshold for Datastore % Free Space
+$WarningDatastorePercentFree = 20
+# Set the critical threshold for Datastore % Free Space
+$CriticalDatastorePercentFree = 10
+# Do not report on any Datastores that are defined here (Datastore Free Space Plugin)
+$DatastoreIgnore = "local"
+# End of Settings
+
+# ChangeLog
+# 1.0 - Initial script
+# 1.1 - 
+
+$DatastoreClustersCapicity = @(Get-DatastoreCluster | Sort Name | Where-Object {$_.Name -notmatch $DatastoreIgnore} | Select-Object Name, @{N="CapacityGB";E={[math]::Round($_.CapacityGB, 2)}}, @{N="FreeSpaceGB";E={[math]::Round($_.FreeSpaceGB, 2)}}, @{N="PercentFree";E={[math]::Round(($_.FreeSpaceGB / $_.CapacityGB) * 100, 2)}} | Sort-Object Name)
+
+$OutputDatastoreSpaceUtilization = @()
+ForEach ($Cluster in $DatastoreClustersCapicity){
+    $ClusterObj = "" | Select Cluster, DataStore, VMGuest, CapacityGB, FreeSpaceGB, PercentFree
+    $ClusterObj.Cluster = $Cluster.Name
+    $ClusterObj.DataStore = $null
+    $ClusterObj.VMGuest = $null
+    $ClusterObj.CapacityGB = $Cluster.CapacityGB
+    $ClusterObj.FreeSpaceGB = $Cluster.FreeSpaceGB
+    $ClusterObj.PercentFree = $Cluster.PercentFree
+
+	$OutputDatastoreSpaceUtilization += $ClusterObj
+
+    $DataStoresCapacity = Get-Datastore -RelatedObject $Cluster.Name | Select-Object Name, @{N="CapacityGB";E={[math]::Round($_.CapacityGB, 2)}}, @{N="FreeSpaceGB";E={[math]::Round($_.FreeSpaceGB, 2)}}, @{N="PercentFree";E={[math]::Round(($_.FreeSpaceGB / $_.CapacityGB) * 100, 2)}} | Sort-Object Name
+    ForEach ($DataStore in $DataStoresCapacity){
+        $DataStoreObj = "" | Select Cluster, DataStore, VMGuest, CapacityGB, FreeSpaceGB, PercentFree
+        $DatastoreObj.Cluster = $null
+        $DatastoreObj.DataStore = $DataStore.Name
+        $DatastoreObj.VMGuest = $null
+        $DatastoreObj.CapacityGB = $DataStore.CapacityGB
+        $DatastoreObj.FreeSpaceGB = $DataStore.FreeSpaceGB
+        $DatastoreObj.PercentFree = [math]::Round(($DataStore.FreeSpaceGB / $DataStore.CapacityGB) * 100, 2)
+        
+		$OutputDatastoreSpaceUtilization += $DatastoreObj
+
+        $VMGuestCapacity = Get-VM -Datastore $DataStore.Name | Sort-Object Name
+        ForEach ($VMGuest in $VMGuestCapacity){
+            $VMGuestObj = "" | Select Cluster, DataStore, VMGuest, CapacityGB, FreeSpaceGB, PercentFree
+            $VMGuestObj.Cluster = $null
+            $VMGuestObj.DataStore = $null
+            $VMGuestObj.VMGuest = $VMGuest.Name
+            $VMGuestObj.CapacityGB = [math]::Round($VMGuest.ProvisionedSpaceGB, 2)
+            $VMGuestObj.FreeSpaceGB = [math]::Round(($VMGuest.ProvisionedSpaceGB - $VMGuest.UsedSpaceGB), 2)
+            $VMGuestObj.PercentFree = "NA"
+
+    		$OutputDatastoreSpaceUtilization += $VMGuestObj
+	    }
+	}
+}
+
+$OutputDatastoreSpaceUtilization
+
+$Title = "Datastore Disk Utilization Information"
+$Header = "Datastore Disk Utilization Information"
+$Comments = "Datastores which run out of space will cause impact on the virtual machines held on these datastore"
+$Display = "Table"
+$Author = "Dan Rowe"
+$PluginVersion = 1.1
+$PluginCategory = "vSphere"
+
+$TableFormat = @{"DataStore"   = @(@{ "-like '[A-Za-z]*'"                 = "BeginShowHideBlock,style|display: none"});
+                 "Cluster"     = @(@{ "-like '[A-Za-z]*'"                 = "EndShowHideBlock,style|display: "});
+                 "PercentFree" = @(@{ "-le $CriticalDatastorePercentFree" = "Row,class|critical"; },
+		 		  			       @{ "-le $WarningDatastorePercentFree"  = "Row,class|warning" });
+                }
+Enter file contents here

--- a/Styles/CleanGreen/Style.ps1
+++ b/Styles/CleanGreen/Style.ps1
@@ -109,6 +109,18 @@ $ReportHTML = @"
          .warning { background: #FFFBAA !important }
 			.critical { background: #FFDDDD !important }
       </style>
+      <script type='text/javascript'> 
+           function showHideBlock(blockId) { 
+               block = document.getElementById(blockId); 
+               if (block.style.display == 'none') { 
+                   block.style.display = ''; 
+               } 
+               else { 
+                   block.style.display = 'none'; 
+               } 
+               return false; 
+           } 
+       </script> 
 	</head>
 	<body style="padding: 0 10px; margin: 0px; font-family:Arial, Helvetica, sans-serif; ">
       <a name="top" />

--- a/Styles/VMware/Style.ps1
+++ b/Styles/VMware/Style.ps1
@@ -115,6 +115,18 @@ $ReportHTML = @"
          .warning { background: #FFFBAA !important }
          .critical { background: #FFDDDD !important }
       </style>
+      <script type='text/javascript'>
+          function showHideBlock(blockId) {
+              block = document.getElementById(blockId);
+              if (block.style.display == 'none') {
+                  block.style.display = '';
+              }
+              else {
+                  block.style.display = 'none';
+              }
+              return false;
+          }
+      </script>
    </head>
    <body style="padding: 0 10px; margin: 0px; font-family:Arial, Helvetica, sans-serif; ">
       <a name="top" />

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -306,32 +306,48 @@ Function Get-HTMLTable {
 										$XMLTable.table.tr[$RowN].selectSingleNode("td[$($ColN + 1)]").SetAttribute($RuleActions[0], $RuleActions[1])
 									}
 								}
-								"BeginShowHideBlock"  {
+								"BegintbodyBlock" {
 									if ($ActiveBlock -eq $true) {
 										$NewElement = $XMLTable.CreateElement("tbody")
 										$XMLTable.table.selectSingleNode("tr[$($RowN+1)]").PrependChild($NewElement) | Out-Null
 										$ActiveBlock = $false
 									}
 
-									$NewElement = $XMLTable.CreateElement("a")
-									$NewElement.SetAttribute("href", "_self")
-									$NewElement.SetAttribute("onclick", "showHideBlock('Block$RowN')")
-									$XMLTable.table.tr[$RowN].selectSingleNode("td[$($ColN+1)]").PrependChild($NewElement) | Out-Null
-
 									$ActiveBlock = $true
-
 									$NewElement = $XMLTable.CreateElement("tbody")
-									$NewElement.SetAttribute("id", "Block$RowN")
-									$NewElement.SetAttribute("style", "display: none")
-									$XMLTable.table.selectSingleNode("tr[$($RowN+1)]").AppendChild($NewElement) | Out-Null
+									$BlockName = "Block" + $RowN
+									$ActiveAnchor = $false
 
+									for ($RuleActionNum = 0; $RuleActions[$RuleActionNum]; $RuleActionNum++) {
+										if ($RuleActions[$RuleActionNum] -eq "a") {
+											if ($ActiveAnchor -eq $false) {
+												$NewAnchor = $XMLTable.CreateElement("a")
+												$ActiveAnchor = $true
+											}
+
+											$RuleActionNum++
+											$RuleActions[$($RuleActionNum+1)] = $RuleActions[$($RuleActionNum+1)] -replace "UID", $BlockName
+											$NewAnchor.SetAttribute($RuleActions[$RuleActionNum], $RuleActions[$($RuleActionNum+1)])
+										} else {
+											$RuleActions[$($RuleActionNum+1)] = $RuleActions[$($RuleActionNum+1)] -replace "UID", $BlockName
+											$NewElement.SetAttribute($RuleActions[$RuleActionNum], $RuleActions[$($RuleActionNum+1)])
+										}
+										
+										$RuleActionNum++
+									}
+
+									if ($ActiveAnchor -eq $true) {
+										$XMLTable.table.tr[$RowN].selectSingleNode("td[$($ColN+1)]").PrependChild($NewAnchor) | Out-Null
+									}
+
+									$XMLTable.table.selectSingleNode("tr[$($RowN+1)]").AppendChild($NewElement) | Out-Null
 								}
-								"EndShowHideBlock"  {
+								"EndtbodyBlock" {
 									if ($ActiveBlock -eq $true) {
 										$NewElement = $XMLTable.CreateElement("tbody")
 										$XMLTable.table.selectSingleNode("tr[$($RowN+1)]").PrependChild($NewElement) | Out-Null
-     										$ActiveBlock = $false
-     									}
+										$ActiveBlock = $false
+									}
 								}
 							}
 						}


### PR DESCRIPTION
Added functionality to Get-HTMLTable in vCheck.ps1 for new rule scopes beginning (BegintbodyBlock) and ending (EndtbodyBlock) a tbody section in a table.  This includes the ability to create Expandable/Collapsible blocks to tables. This request also includes a new plugin that utilizes this functionality.  The plugin will display the DataStore Clusters, DataStores per DS Cluster and the VMs per DataStore.  For each level it shows Disk Capacity, Free Space and if applicable Percent Free.  The VMs are hidden until a datastore is clicked on.

The table formatting allows for multiple settings to be applied to the tbody section accept for a special anchor (a) identifier which is applied to the trigger cell.  The begin tbody section starts at the next row after the trigger criteria.  The end tbody section is placed at the beginning of the row that is triggered by an end tbody call or the next triggered begin tbody section.  A special case for the end tbody section will be triggered at the table end if there is an open tbody section.

![disk utilization datastore collapsed](https://cloud.githubusercontent.com/assets/13473416/8878323/fe5b055c-31ef-11e5-8dff-fb29fa0f59a2.jpg)
![disk utilization datastore expanded](https://cloud.githubusercontent.com/assets/13473416/8878324/fe5ee5c8-31ef-11e5-9c0f-7293b861fbdd.jpg)

