### PR TITLE
Update 79 Find VMs in Uncontrolled Snapshot Mode.ps1 Issue #217

### DIFF
--- a/Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1
+++ b/Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1
@@ -2,38 +2,32 @@
 # End of Settings
 
 $VMFolder = @()
-foreach ($eachVM in $FullVM) {
-  if (!$eachVM.snapshot) { # Only process VMs without snapshots
-    $eachVM.Summary.Config.VmPathName -match '^\[([^\]]+)\] ([^/]+)' > $null
-    $Datastore = $matches[1]
-    $VMPath = $matches[2]
-    $DC = Get-Datacenter -VM $eachVM.Name
-    if ($DC.ParentFolder.Parent) { #Check if Datacenter has a parent folder
-      $DCPath = $DC.ParentFolder.Name
+foreach ($eachDS in $Datastores) {
+    $FilePath = $eachDS.DatastoreBrowserPath + '\*\*delta.vmdk*'
+    $fileList = Get-ChildItem -Path "$FilePath" | Select Name, FolderPath, FullName
+    $FilePath = $eachDS.DatastoreBrowserPath + '\*\-*-flat.vmdk'
+    $fileList += Get-ChildItem -Path "$FilePath" | Select Name, FolderPath, FullName
+
+    foreach ($vmFile in $filelist | sort FolderPath) {
+        $vmFile.FolderPath -match '^\[([^\]]+)\] ([^/]+)' > $null
+        $VMName = $matches[2]
+        $eachVM = $FullVM | where {$_.Name -eq $VMName}
+        if (!$eachVM.snapshot) { # Only process VMs without snapshots
+            $Details = "" | Select-Object VM, Datacenter, Path
+            $Details.VM = $eachVM.Name
+            $Details.Datacenter = $eachDS.Datacenter
+            $Details.Path = $vmFile.FullName
+            $VMFolder += $Details
+        }
     }
-    else {
-      $DCPath = ''
-    }
-    $gciloc = (Get-ChildItem vmstores: | Select -first 1).Name
-    $fileList = Get-ChildItem "vmstores:\$gciloc\$DCPath\$DC\$Datastore\$VMPath"
-    foreach ($file in $fileList) {
-      if ($file.Name -like '*delta.vmdk*' -or $file -like '-*-flat.vmdk') { 
-        $Details = "" | Select-Object VM, Datacenter, Path
-        $Details.VM = $eachVM.Name
-        $Details.Datacenter = $DC.Name
-        $Details.Path = $Datastore + '/' + $VMPath + '/' + $file.Name
-        $VMFolder += $Details
-        break
-      }
-    }
-  }
 }
-$VMFolder
+$Results = $VMFolder | sort VM
+$Results
 
 $Title = "VMs in uncontrolled snapshot mode"
 $Header = "VMs in uncontrolled snapshot mode: $(@($Result).Count)"
 $Comments = "The following VMs are in snapshot mode, but vCenter isn't aware of it. See http://kb.vmware.com/kb/1002310"
 $Display = "Table"
-$Author = "Rick Glover, Matthias Koehler"
-$PluginVersion = 1.3
+$Author = "Rick Glover, Matthias Koehler, Dan Rowe"
+$PluginVersion = 1.4
 $PluginCategory = "vSphere"


### PR DESCRIPTION
Modified script to solve issue #217 at my site.  The change was made to search each Datastore for all VMs that have files named like *delta.vmdk* and -*-flat.vmdk.  In doing the file search this way there is only 2 calls per Datastore and only getting the information needed not other files that are not needed.  This eliminates calling Get-Datacenter and retrieving all files for each VM.  The question I would have is in the current script the line 

    if ($file.Name -like '*delta.vmdk*' -or $file -like '-*-flat.vmdk') {

Is the 'or' portion of the statement was that meant to be $file or $file.Name?  And based on what is in quotes the file starts with '-' (a hyphen)?

At my site the current version of "79 Find VMs in Uncontrolled Snapshot Mode.ps1" it ran for 2:40:03 and with this version it runs in 0:16:20 and I was able to run it with all the full vCheck.ps1 run.  At my sight we do not have any uncontrolled snapshots showing up with either version so I would appreciate it if someone could verify that it works the same as the original version.

Thank you