### PR TITLE
Create tbody section in table including Expandable/Collapsable Blocks (original was pull request #406)

### DIFF
--- a/Plugins/40 Datastore/333 Disk Utilization DataStore Cluster and Datastore.ps1
+++ b/Plugins/40 Datastore/333 Disk Utilization DataStore Cluster and Datastore.ps1
@@ -1,0 +1,69 @@
+# Start of Settings 
+# Set the warning threshold for Datastore % Free Space
+$WarningDatastorePercentFree = 20
+# Set the critical threshold for Datastore % Free Space
+$CriticalDatastorePercentFree = 10
+# Do not report on any Datastores that are defined here (Datastore Free Space Plugin)
+$DatastoreIgnore = "local"
+# End of Settings
+
+# ChangeLog
+# 1.1 - Changed Table Formating setup for Expandable/Collapsible blocks
+# 1.2 - Changed how it finds the Datastores for each Cluster and VMs for each Datastore
+
+$DatastoreClustersCapicity = @(Get-DatastoreCluster | Where-Object {$_.Name -notmatch $DatastoreIgnore} | Sort-Object Name)
+
+$OutputDatastoreSpaceUtilization = @()
+ForEach ($Cluster in $DatastoreClustersCapicity){
+    $ClusterObj = "" | Select Cluster, DataStore, VMGuest, CapacityGB, FreeSpaceGB, PercentFree
+    $ClusterObj.Cluster = $Cluster.Name
+    $ClusterObj.DataStore = $null
+    $ClusterObj.VMGuest = $null
+    $ClusterObj.CapacityGB = [math]::Round($Cluster.CapacityGB, 2)
+    $ClusterObj.FreeSpaceGB = [math]::Round($Cluster.FreeSpaceGB, 2)
+    $ClusterObj.PercentFree = [math]::Round(($Cluster.FreeSpaceGB / $Cluster.CapacityGB) * 100, 2)
+
+	$OutputDatastoreSpaceUtilization += $ClusterObj
+
+    ForEach ($eachDs in $Cluster.ExtensionData.ChildEntity) {
+        $DSID = $eachDs.Type + '-' + $eachDs.Value
+        $DataStoreObj = "" | Select Cluster, DataStore, VMGuest, CapacityGB, FreeSpaceGB, PercentFree
+        $DatastoreObj.Cluster = $null
+        $DatastoreObj.DataStore = $Datastores[$DSIDHash[$DSID]].Name
+        $DatastoreObj.VMGuest = $null
+        $DatastoreObj.CapacityGB = [math]::Round($Datastores[$DSIDHash[$DSID]].CapacityGB, 2)
+        $DatastoreObj.FreeSpaceGB = [math]::Round($Datastores[$DSIDHash[$DSID]].FreeSpaceGB, 2)
+        $DatastoreObj.PercentFree = [math]::Round(($Datastores[$DSIDHash[$DSID]].FreeSpaceGB / $Datastores[$DSIDHash[$DSID]].CapacityGB) * 100, 2)
+        
+		$OutputDatastoreSpaceUtilization += $DatastoreObj
+
+        ForEach ($eachVM in $Datastores[$DSIDHash[$DSID]].ExtensionData.Vm) {
+            $VMID = $eachVM.Type + '-' + $eachVM.Value
+            $VMGuestObj = "" | Select Cluster, DataStore, VMGuest, CapacityGB, FreeSpaceGB, PercentFree
+            $VMGuestObj.Cluster = $null
+            $VMGuestObj.DataStore = $null
+            $VMGuestObj.VMGuest = $VM[$VMIDHash[$VMID]].Name
+            $VMGuestObj.CapacityGB = [math]::Round($VM[$VMIDHash[$VMID]].ProvisionedSpaceGB, 2)
+            $VMGuestObj.FreeSpaceGB = [math]::Round(($VM[$VMIDHash[$VMID]].ProvisionedSpaceGB - $VM[$VMIDHash[$VMID]].UsedSpaceGB), 2)
+            $VMGuestObj.PercentFree = "NA"
+
+    		$OutputDatastoreSpaceUtilization += $VMGuestObj
+	    }
+	}
+}
+
+$OutputDatastoreSpaceUtilization
+
+$Title = "Datastore Disk Utilization Information"
+$Header = "Datastore Disk Utilization Information"
+$Comments = "Datastores which run out of space will cause impact on the virtual machines held on these datastore"
+$Display = "Table"
+$Author = "Dan Rowe"
+$PluginVersion = 1.2
+$PluginCategory = "vSphere"
+
+$TableFormat = @{"DataStore"   = @(@{ "-like '[A-Za-z]*'"                 = "BegintbodyBlock,a|href|#Block|a|onclick|showHideBlock('UID')|id|UID|style|background-color: lightgray;display: none"});
+                 "Cluster"     = @(@{ "-like '[A-Za-z]*'"                 = "EndtbodyBlock,style|display: "});
+                 "PercentFree" = @(@{ "-le $CriticalDatastorePercentFree" = "Row,class|critical"; },
+		 		  			       @{ "-le $WarningDatastorePercentFree"  = "Row,class|warning" });
+                }

--- a/Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1
+++ b/Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1
@@ -2,38 +2,32 @@
 # End of Settings
 
 $VMFolder = @()
-foreach ($eachVM in $FullVM) {
-  if (!$eachVM.snapshot) { # Only process VMs without snapshots
-    $eachVM.Summary.Config.VmPathName -match '^\[([^\]]+)\] ([^/]+)' > $null
-    $Datastore = $matches[1]
-    $VMPath = $matches[2]
-    $DC = Get-Datacenter -VM $eachVM.Name
-    if ($DC.ParentFolder.Parent) { #Check if Datacenter has a parent folder
-      $DCPath = $DC.ParentFolder.Name
+foreach ($eachDS in $Datastores) {
+    $FilePath = $eachDS.DatastoreBrowserPath + '\*\*delta.vmdk*'
+    $fileList = Get-ChildItem -Path "$FilePath" | Select Name, FolderPath, FullName
+    $FilePath = $eachDS.DatastoreBrowserPath + '\*\-*-flat.vmdk'
+    $fileList += Get-ChildItem -Path "$FilePath" | Select Name, FolderPath, FullName
+
+    foreach ($vmFile in $filelist | sort FolderPath) {
+        $vmFile.FolderPath -match '^\[([^\]]+)\] ([^/]+)' > $null
+        $VMName = $matches[2]
+        $eachVM = $FullVM | where {$_.Name -eq $VMName}
+        if (!$eachVM.snapshot) { # Only process VMs without snapshots
+            $Details = "" | Select-Object VM, Datacenter, Path
+            $Details.VM = $eachVM.Name
+            $Details.Datacenter = $eachDS.Datacenter
+            $Details.Path = $vmFile.FullName
+            $VMFolder += $Details
+        }
     }
-    else {
-      $DCPath = ''
-    }
-    $gciloc = (Get-ChildItem vmstores: | Select -first 1).Name
-    $fileList = Get-ChildItem "vmstores:\$gciloc\$DCPath\$DC\$Datastore\$VMPath"
-    foreach ($file in $fileList) {
-      if ($file.Name -like '*delta.vmdk*' -or $file -like '-*-flat.vmdk') { 
-        $Details = "" | Select-Object VM, Datacenter, Path
-        $Details.VM = $eachVM.Name
-        $Details.Datacenter = $DC.Name
-        $Details.Path = $Datastore + '/' + $VMPath + '/' + $file.Name
-        $VMFolder += $Details
-        break
-      }
-    }
-  }
 }
-$VMFolder
+$Results = $VMFolder | sort VM
+$Results
 
 $Title = "VMs in uncontrolled snapshot mode"
 $Header = "VMs in uncontrolled snapshot mode: $(@($Result).Count)"
 $Comments = "The following VMs are in snapshot mode, but vCenter isn't aware of it. See http://kb.vmware.com/kb/1002310"
 $Display = "Table"
-$Author = "Rick Glover, Matthias Koehler"
-$PluginVersion = 1.3
+$Author = "Rick Glover, Matthias Koehler, Dan Rowe"
+$PluginVersion = 1.4
 $PluginCategory = "vSphere"

--- a/Styles/CleanGreen/Style.ps1
+++ b/Styles/CleanGreen/Style.ps1
@@ -109,6 +109,18 @@ $ReportHTML = @"
          .warning { background: #FFFBAA !important }
 			.critical { background: #FFDDDD !important }
       </style>
+      <script type='text/javascript'>
+          function showHideBlock(blockId) {
+              block = document.getElementById(blockId);
+              if (block.style.display == 'none') {
+                  block.style.display = '';
+              }
+              else {
+                  block.style.display = 'none';
+              }
+              return false;
+          }
+      </script>
 	</head>
 	<body style="padding: 0 10px; margin: 0px; font-family:Arial, Helvetica, sans-serif; ">
       <a name="top" />

--- a/Styles/VMware/Style.ps1
+++ b/Styles/VMware/Style.ps1
@@ -115,6 +115,18 @@ $ReportHTML = @"
          .warning { background: #FFFBAA !important }
          .critical { background: #FFDDDD !important }
       </style>
+      <script type='text/javascript'>
+          function showHideBlock(blockId) {
+              block = document.getElementById(blockId);
+              if (block.style.display == 'none') {
+                  block.style.display = '';
+              }
+              else {
+                  block.style.display = 'none';
+              }
+              return false;
+          }
+      </script>
    </head>
    <body style="padding: 0 10px; margin: 0px; font-family:Arial, Helvetica, sans-serif; ">
       <a name="top" />

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -260,7 +260,10 @@ Function Get-HTMLTable {
 	
 	# Use an XML object for ease of use
 	$XMLTable = [xml]($content | ConvertTo-Html -Fragment)
+    $XMLTable.table.RemoveChild($XMLTable.table.colgroup) | out-null
 	$XMLTable.table.SetAttribute("width", "100%")
+
+	$ActiveBlock = $false
 	
 	# If format rules are specified
 	if ($FormatRules) {
@@ -304,11 +307,60 @@ Function Get-HTMLTable {
 										$XMLTable.table.tr[$RowN].selectSingleNode("td[$($ColN + 1)]").SetAttribute($RuleActions[0], $RuleActions[1])
 									}
 								}
+								"BegintbodyBlock" {
+									if ($ActiveBlock -eq $true) {
+										$NewElement = $XMLTable.CreateElement("tbody")
+										$XMLTable.table.selectSingleNode("tr[$($RowN+1)]").PrependChild($NewElement) | Out-Null
+										$ActiveBlock = $false
+									}
+
+									$ActiveBlock = $true
+									$NewElement = $XMLTable.CreateElement("tbody")
+									$BlockName = "Block" + $RowN
+									$ActiveAnchor = $false
+
+									for ($RuleActionNum = 0; $RuleActions[$RuleActionNum]; $RuleActionNum++) {
+										if ($RuleActions[$RuleActionNum] -eq "a") {
+											if ($ActiveAnchor -eq $false) {
+												$NewAnchor = $XMLTable.CreateElement("a")
+												$ActiveAnchor = $true
+											}
+
+											$RuleActionNum++
+											$RuleActions[$($RuleActionNum+1)] = $RuleActions[$($RuleActionNum+1)] -replace "UID", $BlockName
+											$NewAnchor.SetAttribute($RuleActions[$RuleActionNum], $RuleActions[$($RuleActionNum+1)])
+										} else {
+											$RuleActions[$($RuleActionNum+1)] = $RuleActions[$($RuleActionNum+1)] -replace "UID", $BlockName
+											$NewElement.SetAttribute($RuleActions[$RuleActionNum], $RuleActions[$($RuleActionNum+1)])
+										}
+
+										$RuleActionNum++
+									}
+
+									if ($ActiveAnchor -eq $true) {
+										$XMLTable.table.tr[$RowN].selectSingleNode("td[$($ColN+1)]").PrependChild($NewAnchor) | Out-Null
+									}
+
+									$XMLTable.table.selectSingleNode("tr[$($RowN+1)]").AppendChild($NewElement) | Out-Null
+								}
+								"EndtbodyBlock" {
+									if ($ActiveBlock -eq $true) {
+										$NewElement = $XMLTable.CreateElement("tbody")
+										$XMLTable.table.selectSingleNode("tr[$($RowN+1)]").PrependChild($NewElement) | Out-Null
+										$ActiveBlock = $false
+									}
+								}
 							}
 						}
 					}
 				}
 			}
+		}
+		if ($ActiveBlock -eq $true) {
+			$RowN = $XMLTable.table.tr.count - 1
+			$NewElement = $XMLTable.CreateElement("tbody")
+			$XMLTable.table.selectSingleNode("tr[$($RowN+1)]").AppendChild($NewElement) | Out-Null
+			$ActiveBlock = $false
 		}
 	}
 	return (Format-HTMLEntities ([string]($XMLTable.OuterXml)))


### PR DESCRIPTION
Added functionality to Get-HTMLTable in vCheck.ps1 for new rule scopes beginning (BegintbodyBlock) and ending (EndtbodyBlock) a tbody section in a table. This includes the ability to create Expandable/Collapsible blocks to tables. This request also includes a new plugin that utilizes this functionality. The plugin will display the DataStore Clusters, DataStores per DS Cluster and the VMs per DataStore. For each level it shows Disk Capacity, Free Space and if applicable Percent Free. The VMs are hidden until a datastore is clicked on.

The table formatting allows for multiple settings to be applied to the tbody section accept for a special anchor (a) identifier which is applied to the trigger cell. The begin tbody section starts at the next row after the trigger criteria. The end tbody section is placed at the beginning of the row that is triggered by an end tbody call or the next triggered begin tbody section. A special case for the end tbody section will be triggered at the table end if there is an open tbody section.

![collapsed block](https://cloud.githubusercontent.com/assets/13473416/9608370/aed15294-5093-11e5-8814-3bb7e39f72f8.jpg)

![expanded block](https://cloud.githubusercontent.com/assets/13473416/9608384/b72538ca-5093-11e5-8a22-35995b01b300.jpg)
