### PR TITLE
Update 01 General Information.ps1

### DIFF
--- a/Plugins/00 Initialize/01 General Information.ps1
+++ b/Plugins/00 Initialize/01 General Information.ps1
@@ -41,7 +41,7 @@ if ($DRSMigrateAge -gt 0) {
 # Adding vSphere 5 informations
 if ($VIVersion -ge 5) {
 	$Info | Add-Member Noteproperty "Number of Datastore Clusters" $(@($DatastoreClustersView).Count)
-	if ($SDRSMigrateAge -gt 0) {
+	if (($MigrationQuery2) -and ($SDRSMigrateAge -gt 0)) {
 		$Info | Add-Member Noteproperty "Storage DRS Migrations for last $($SDRSMigrateAge) Days" (@($MigrationQuery2 | Where {$_.FullFormattedMessage -imatch "(Storage vMotion){1}.*(DRS){1}"}).Count)
 	}
 }


### PR DESCRIPTION
[16:11:13] ..start calculating General Information by Alan Renouf, Frederic Martin v1.2 [2 of 99]
The variable '$MigrationQuery2' cannot be retrieved because it has not been set.
At E:\vCheckLatestTesting\Plugins\00 Initialize\01 General Information.ps1:45 char:96
+ ... rations for last $($SDRSMigrateAge) Days" (@($MigrationQuery2 | Where ...
+                                                  ~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (MigrationQuery2:String) [], RuntimeException
    + FullyQualifiedErrorId : VariableIsUndefined

[16:11:15] ..finished calculating General Information by Alan Renouf, Frederic Martin v1.2 [2 of 99]

==========

In "01 General Information.ps1" line 19 $MigrationQuery2 could have zero results and not be created.  Added test that $MigrationQuery2 exists.
line 44 -- 	if ( ($MigrationQuery2) -and ($SDRSMigrateAge -gt 0) ) {