### PR TITLE
Update 60 Powered Off VMs.ps1

### DIFF
--- a/Plugins/60 VM/60 Powered Off VMs.ps1
+++ b/Plugins/60 VM/60 Powered Off VMs.ps1
@@ -5,7 +5,7 @@ $IgnoredVMs = "Windows7*"
 
 $DecommedVMs = @($VM |
   Where-Object {$_.ExtensionData.Config.ManagedBy.ExtensionKey -ne 'com.vmware.vcDr' -and $_.PowerState -eq "PoweredOff" -and $_.Name -notmatch $IgnoredVMs} |
-  Select-Object -Property Name, LastPoweredOffDate |
+  Select-Object -Property Name, LastPoweredOffDate, Folder, Notes |
   Sort-Object -Property LastPoweredOffDate)
 $DecommedVMs
 
@@ -14,5 +14,5 @@ $Header = "VMs Powered Off - Number of Days"
 $Comments = "May want to consider deleting VMs that have been powered off for more than 30 days"
 $Display = "Table"
 $Author = "Adam Schwartzberg"
-$PluginVersion = 1.2
+$PluginVersion = 1.3
 $PluginCategory = "vSphere"


### PR DESCRIPTION
Adds some information that helps me decide if I want to follow up on the powered off VM.  In particular for us is our VM decommissioning process.  VMs are moved to a folder "decom" and the notes are updated with the deletion date after a 2 week waiting period.