### PR TITLE
Support PowerCLI 6.x for VDS Module

### DIFF
--- a/Plugins/50 Network/80 DvPG with less than x Ports Free.ps1
+++ b/Plugins/50 Network/80 DvPG with less than x Ports Free.ps1
@@ -3,7 +3,7 @@
 $DvSwitchLeft = 10
 # End of Settings
 
-if (Get-PSSnapin VMware.VimAutomation.Vds -ErrorAction SilentlyContinue)
+if ( (Get-PSSnapin VMware.VimAutomation.Vds -ErrorAction SilentlyContinue) -or (Import-Module VMware.VimAutomation.Vds -PassThru -ErrorAction SilentlyContinue))
 {
     if ($vdspg = Get-VDSwitch | Sort-Object -Property Name | Get-VDPortgroup)
     {

--- a/Plugins/50 Network/80 DvPG with less than x Ports Free.ps1
+++ b/Plugins/50 Network/80 DvPG with less than x Ports Free.ps1
@@ -3,7 +3,7 @@
 $DvSwitchLeft = 10
 # End of Settings
 
-if ( (Get-PSSnapin VMware.VimAutomation.Vds -ErrorAction SilentlyContinue) -or (Import-Module VMware.VimAutomation.Vds -PassThru -ErrorAction SilentlyContinue))
+if ((Get-PSSnapin VMware.VimAutomation.Vds -ErrorAction SilentlyContinue) -or (Get-Module VMware.VimAutomation.Vds -ErrorAction SilentlyContinue))
 {
     if ($vdspg = Get-VDSwitch | Sort-Object -Property Name | Get-VDPortgroup)
     {

--- a/Plugins/50 Network/98 vSwitch Security.ps1
+++ b/Plugins/50 Network/98 vSwitch Security.ps1
@@ -19,9 +19,17 @@ $VersionOK = $false
 if (((Get-PowerCLIVersion) -match "VMware vSphere PowerCLI (.*) build ([0-9]+)")) {
    if ([int]($Matches[2]) -ge 1012425) {
       $VersionOK = $true
-      # Add required Snap-In
-      if (!(Get-PSSnapin -name VMware.VimAutomation.Vds -ErrorAction SilentlyContinue)) {
-         Add-PSSnapin VMware.VimAutomation.Vds
+      if ([int]($Matches[2]) -ge 2548067) {
+        #PowerCLI 6+
+        if(!(Get-Module -Name VMware.VimAutomation.Vds -ErrorAction SilentlyContinue)) {
+           Import-Module VMware.VimAutomation.Vds
+        }
+      }
+      else {
+        # Add required Snap-In
+        if (!(Get-PSSnapin -name VMware.VimAutomation.Vds -ErrorAction SilentlyContinue)) {
+           Add-PSSnapin VMware.VimAutomation.Vds
+        }
       }
    }
 }


### PR DESCRIPTION
In PowerCLI 6.x the VMware.VimAutomation.Vds has been moved to a module, rather than a snapin.  I added code to support this, while also supporting previous PowerCLI versions that still use snapins.