### PR TITLE
Create 125 VMs with Isolated Configuration Files

### DIFF
--- a/Plugins/60 VM/125 VMs with Isolated Configuration Files
+++ b/Plugins/60 VM/125 VMs with Isolated Configuration Files
@@ -1,0 +1,32 @@
+# Start of Settings
+# End of Settings 
+
+$isolatedVMXs = @()
+Foreach ($CHKVM in $FullVM){
+	$Details = "" | Select-Object VM,VmxDatastore,VmdkDatastores
+	$vmxDatastore = (($CHKVM.Summary.Config.VmPathName).Split(']')[0].TrimStart('['))
+    $vmdkDatastores = @()
+	$CHKVM.Config.Hardware.Device | % {
+        If ($_.Backing.Filename -ne $null) 
+        {
+            $vmdkDatastores += ($_.Backing.Filename).Split(']')[0].TrimStart('[')
+        }
+    }
+    
+	If ( -not ($vmdkDatastores.Contains($vmxDatastore)))
+    {
+		$Details.VM= $CHKVM.Name
+		$Details.VmxDatastore = $vmxDatastore
+        $Details.VmdkDatastores = $vmdkDatastores -join ", "
+		$isolatedVMXs += $Details
+    }
+}
+$isolatedVMXs
+
+$Title = "VMs with configuration files (*.vmx, etc) isolated from their disks"
+$Header = "VMs with configuration files (*.vmx, etc) isolated from their disks $(@($isolatedVMXs).Count)"
+$Comments = "The following VMs have their configuration files (*.vmx, etc) stored in a different datastore than their disks"
+$Display = "Table"
+$Author = "Kristofor Hines"
+$PluginVersion = 1.0
+$PluginCategory = "vSphere"


### PR DESCRIPTION
This plugin will list all VMs with configuration files (_.vmx, etc) on different datastores than their disks (_.vmdks). This can cause issues with some programs, such as CommVault VM backups
