### PR TITLE
Automate configuration and credential management

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -1,2 +1,3 @@
 # Ignore Windowscreds.xml
 Windowscreds.xml
+vCenterCreds.xml

--- a/GlobalVariables.ps1
+++ b/GlobalVariables.ps1
@@ -41,6 +41,8 @@ $ListEnabledPluginsFirst = $true
 $TimeToRun = $true
 # Report on plugins that take longer than the following amount of seconds
 $PluginSeconds = 30
+# Specify the location to save the vCenter credentials (with the password encrypted as a SecureString) on disk
+$vCenterCredentialsFile = "${ScriptPath}\vCenterCreds.xml"
 # End of Settings
 
 # End of Global Variables

--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -47,7 +47,7 @@ else
    $port = 443
 }
 
-# Path to credentials file which is automatically created if needed
+# Path to Windows credentials file which is automatically created if needed
 $Credfile = $ScriptPath + "\Windowscreds.xml"
 
 # Adding PowerCLI core snapin, also check if powerCLI module is alsready added
@@ -63,7 +63,14 @@ if($OpenConnection.IsConnected) {
 	$VIConnection = $OpenConnection
 } else {
 	Write-CustomOut ( "{0}: {1}" -f $pLang.connOpen, $Server )
-	$VIConnection = Connect-VIServer -Server $VIServer -Port $Port
+    if ( (Get-ChildItem $vCenterCredentialsFile).length -ne 0) {
+        $vCenterCredentials = Retrieve-vCenterCredentials($vCenterCredentialsFile)
+        $Credentials = new-object -typename System.Management.Automation.PSCredential -argumentlist $vCenterCredentials.Username,$vCenterCredentials.Password
+    	$VIConnection = Connect-VIServer -Server $VIServer -Port $Port -Credential $Credentials
+    }
+    else {   
+    	$VIConnection = Connect-VIServer -Server $VIServer -Port $Port
+    }
 }
 
 if (-not $VIConnection.IsConnected) {


### PR DESCRIPTION
  New functions Store-vCenterCredentials and Retrieve-vCenterCredentials.
  End vCheck after configuration when running in configuration mode.
  Store credentials securely on disk so that users do not need to hand edit the plugins on installation.
    When credentials are not available, prompt for credentials (preserve current behavior for existing users).
  gitignore the new vCenter credentials file.
  Prevent modified files from being mojibaked by little endian BOMs (http://stackoverflow.com/questions/10655788/powershell-set-content-and-out-file-what-is-the-difference)
