### PR TITLE
Enhancement Added command line parameters Server and DataCenter to vCheck

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -7,8 +7,6 @@ $Display = "List"
 $PluginCategory = "vSphere"
 
 # Start of Settings
-# Please Specify the address (and optional port) of the vCenter server to connect to [servername(:port)]
-$Server = "192.168.0.0"
 # Maximum number of samples to gather for events
 $MaxSampleVIEvent = 100000
 # End of Settings
@@ -111,14 +109,26 @@ New-VIProperty -Name "HWVersion" -ObjectType VirtualMachine -Value {
 	$vm.ExtensionData.Config.Version.Substring(4)
 } -BasedOnExtensionProperty "Config.Version" -Force | Out-Null
 
-Write-CustomOut $pLang.collectVM
-$VM = Get-VM | Sort Name
-Write-CustomOut $pLang.collectHost
-$VMH = Get-VMHost | Sort Name
-Write-CustomOut $pLang.collectCluster
-$Clusters = Get-Cluster | Sort Name
-Write-CustomOut $pLang.collectDatastore
-$Datastores = Get-Datastore | Sort Name
+if ( $DataCenter ) {
+	Write-CustomOut $pLang.collectVM
+	$VM = Get-VM -Location "$DataCenter" | Sort Name
+	Write-CustomOut $pLang.collectHost
+	$VMH = Get-VMHost -Location "$DataCenter" | Sort Name
+	Write-CustomOut $pLang.collectCluster
+	$Clusters = Get-Cluster -Location "$DataCenter" | Sort Name
+	Write-CustomOut $pLang.collectDatastore
+	$Datastores = Get-Datastore -Location "$DataCenter" | Sort Name
+ } else {
+	Write-CustomOut $pLang.collectVM
+	$VM = Get-VM | Sort Name
+	Write-CustomOut $pLang.collectHost
+	$VMH = Get-VMHost | Sort Name
+	Write-CustomOut $pLang.collectCluster
+	$Clusters = Get-Cluster | Sort Name
+	Write-CustomOut $pLang.collectDatastore
+	$Datastores = Get-Datastore | Sort Name
+}
+
 Write-CustomOut $pLang.collectDVM
 $FullVM = Get-View -ViewType VirtualMachine | Where {-not $_.Config.Template}
 Write-CustomOut $pLang.collectTemplate 

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -64,6 +64,7 @@ param (
 	[ValidateScript({ Test-Path $_ -PathType 'Leaf' })]
 	[string]$job,
 
+	# Please Specify the address (and optional port) of the vCenter server to connect to [servername(:port)]
 	[string]$Server = "192.168.0.0",
 
 	[string]$DataCenter = ""

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -62,10 +62,15 @@ param (
 	[string]$Outputpath=$Env:TEMP,
 
 	[ValidateScript({ Test-Path $_ -PathType 'Leaf' })]
-	[string]$job
+	[string]$job,
+
+	[string]$Server = "192.168.0.0",
+
+	[string]$DataCenter = ""
+
 )
 
-$vCheckVersion = "6.23-alpha-3"
+$vCheckVersion = "6.24"
 $Date = Get-Date
 
 #region Internationalization


### PR DESCRIPTION


Added support to vCheck allowing optional parameters Server and DataCenter. The Server parameter defaults to whatever is entered during the configuration if it is not provided on the command line. The DataCenter parameter allows the vCheck report to filter commands to a specific DataCenter.

Defaults
 .\vCheck.ps1

Run for non-default server vcServer02
 .\vCheck.ps1 -Server vcServer02

Filter for DataCenter DC01
 .\vCheck.ps1 -DataCenter DC01

Filter for DataCenter DC01 on vcServer02
 .\vCheck.ps1 -Server vcServer02 -DataCenter DC01
