### PR TITLE
00 Connection Plugin for vCenter.ps1 and PowerCLI 6.5R1

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -50,9 +50,36 @@ else
 # Path to credentials file which is automatically created if needed
 $Credfile = $ScriptPath + "\Windowscreds.xml"
 
-# Adding PowerCLI core snapin
-if (!(get-pssnapin -name VMware.VimAutomation.Core -erroraction silentlycontinue)) {
-	add-pssnapin VMware.VimAutomation.Core
+#
+# Adding PowerCLI core module/pssnapin
+#
+# Possibilities:
+# 1) PSSnpain (-le 5.8R1)
+# 2) Module + PSSnapin (-gt 5.8R1/-lt 6.5R1)
+# 3) Module (-ge 6.5R1)
+
+$pcliCore = 'VMware.VimAutomation.Core'
+
+$pssnapinPresent = $false
+$psmodulePresent = $false
+
+if(Get-Module -Name $pcliCore -ListAvailable){
+    $psmodulePresent = $true
+    if(!(Get-Module -Name $pcliCore)){
+        Import-Module -Name $pcliCore
+    }
+}
+
+if(Get-PSSnapin -Name $pcliCore -Registered -ErrorAction SilentlyContinue){
+    $pssnapinPresent = $true
+    if(!(Get-PSSnapin -Name $pcliCore -ErrorAction SilentlyContinue)){
+        Add-PSSnapin -Name $pcliCore
+    }
+}
+
+if(!$pssnapinPresent -and !$psmodulePresent){
+    Write-Error "Can't find PowerCLI. Is it installed?"
+    return
 }
 
 $OpenConnection = $global:DefaultVIServers | where { $_.Name -eq $VIServer }


### PR DESCRIPTION
The logic off the loading of VMware.VimAutomation.Core needs to handle
all possiblilities.

1) pre PCLI 6.0R1: only PSSnapin
2) PCLI 6.0R1 - PCLI 6.3R1: PSSnapin & Modules
3) PCLI 6.5R1: only modules

An additional requirement for option 2, seems to be the fact that module
needs to be loaded before the PSSnapin (see the
Initialize-PowerCLIEnvironment.ps1 script in the releases covered by 2))