### PR TITLE
New features for AD Authentication Plugin

### DIFF
--- a/Plugins/30 Host/29 AD Authentication.ps1
+++ b/Plugins/30 Host/29 AD Authentication.ps1
@@ -1,12 +1,40 @@
 # Start of Settings
+# Show "OK" results?
+$ADDisplayOK = $false
+# Expected Domain name
+$ADDomainName = "mydomain.local"
+# Expected Admin Group
+$ADAdminGroup = "ESX Admins"
 # End of Settings
 
-@($VMH | Where-Object {$_.ExtensionData.Summary.Config.Product.Name -eq 'VMware ESXi'} | Select-Object Name,@{Name='Domain';Expression = {($_ | Get-VMHostAuthentication).Domain}},@{Name='MembershipStatus';Expression = {($_ | Get-VMHostAuthentication).DomainMembershipStatus}},@{Name='AdminGroup';Expression = {($_ | Get-AdvancedSetting -Name "Config.HostAgent.plugins.hostsvc.esxAdminsGroup").Value}})
+#Init arrays
+$ADFailedHosts = @()
+$ADOKHosts = @()
+
+ForEach ($ADHost in $VMH) {
+		# Get authetication settings
+		$myADAuth = $ADHost | Get-VMHostAuthentication
+		# Get Admin Group settings
+		$myADGroup = ($ADHost | Get-AdvancedSetting -Name "Config.HostAgent.plugins.hostsvc.esxAdminsGroup").Value
+		# Build array item
+		$myADHost = $ADHost | Select-Object Name,@{Name='Domain';Expression = {$myADAuth.Domain}},@{Name='MembershipStatus';Expression = {$myADAuth.DomainMembershipStatus}},@{Name='AdminGroup';Expression = {$myADGroup}}
+		# Iterate tests, a single failure constitues a failure for the unit
+		If ($myADAuth.Domain -ne $ADDomainName) {$ADFailedHosts += $myADHost } #Configured domain does not equal expected
+		ElseIf ($myADGroup -ne $ADAdminGroup) {$ADFailedHosts += $myADHost} #Configured Admin Group does not equal expected
+		ElseIf ($myADAuth.DomainMembershipStatus -ne "OK") {$ADFailedHosts += $myADHost} #Domain Memebership is in doubt
+		Else {$ADOKHosts += $myADHost} #Configuration passed all tests
+}
+
+# If desired, add OK hosts to display after failed hosts
+If ($ADDisplayOK) {$ADFailedHosts += $ADOKHosts}
+
+# Provide output
+$ADFailedHosts
 
 $PluginCategory = "vSphere"
 $Title = "Active Directory Authentication"
 $Header = "Active Directory Authentication"
-$Comments = "Active Directory configuration and status for each host."
+$Comments = "Active Directory configuration and status for each host. (Domain: $ADDomainName, Admin Group: $ADAdminGroup, Display all results: $ADDisplayOK)"
 $Display = "Table"
 $Author = "Bill Wall"
-$PluginVersion = 1.0
+$PluginVersion = 1.1


### PR DESCRIPTION
Added expected AD Domain Name and AD Admin Group settings.
Added setting to display all results. By default only displays failed results.
Improved performance. Run time cut by 2/3 in test environment.