### PR TITLE
Replaced Implementation Types with non-Impl types.

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -74,7 +74,7 @@ Write-CustomOut $pLang.custAttr
 
 function Get-VMLastPoweredOffDate {
   param([Parameter(Mandatory=$true,ValueFromPipeline=$true)]
-        [VMware.VimAutomation.ViCore.Impl.V1.Inventory.VirtualMachineImpl] $vm)
+        [VMware.VimAutomation.ViCore.Types.V1.Inventory.VirtualMachine] $vm)
   process {
     $Report = "" | Select-Object -Property Name,LastPoweredOffDate
      $Report.Name = $_.Name
@@ -87,7 +87,7 @@ function Get-VMLastPoweredOffDate {
 
 function Get-VMLastPoweredOnDate {
   param([Parameter(Mandatory=$true,ValueFromPipeline=$true)]
-        [VMware.VimAutomation.ViCore.Impl.V1.Inventory.VirtualMachineImpl] $vm)
+        [VMware.VimAutomation.ViCore.Types.V1.Inventory.VirtualMachine] $vm)
 
   process {
     $Report = "" | Select-Object -Property Name,LastPoweredOnDate
@@ -194,7 +194,7 @@ if ($VIVersion -ge 5) {
 function Get-VIEventPlus {
 	 
 	param(
-		[VMware.VimAutomation.ViCore.Impl.V1.Inventory.InventoryItemImpl[]]$Entity,
+		[VMware.VimAutomation.ViCore.Types.V1.Inventory.InventoryItem[]]$Entity,
 		[string[]]$EventType,
 		[DateTime]$Start,
 		[DateTime]$Finish = (Get-Date),


### PR DESCRIPTION
Updated ./Plugins/00 Connection Plugin for vCenter.ps1 to use non-implementation types per post on [VMware PowerCLI blog](https://blogs.vmware.com/PowerCLI/2016/04/powercli-best-practice-correct-use-strong-typing.html). 

Impacted parameter strong-typing on functions Get-VMLastPoweredOffDate, Get-VMLastPoweredOnDate, and Get-VIEventPlus. 

Should resolve Issue #526 