### PR TITLE
Create 49 EVC Mismatch.ps1

### DIFF
--- a/Plugins/60 VM/49 EVC Mismatch.ps1
+++ b/Plugins/60 VM/49 EVC Mismatch.ps1
@@ -1,0 +1,28 @@
+# Start of Settings
+# End of Settings
+
+# Init arrays
+$EVCMismatchedVMs = @()
+
+# For Each Host
+ForEach ($EVCHost in $VMH) {
+		## Get cluster EVC mode
+		$myHostEVCMode = $EVCHost.Parent.EVCMode
+
+		## Get cluster name
+		$myHostEVCCluster = $EVCHost.Parent.Name
+
+		## Get VMs on current host | Filter by Powered On and VM EVC not equal to host EVC | Select VM, Host and Cluster information and concatenate into array 
+		$EVCMismatchedVMs += Get-VM -Location $EVCHost | Where-Object {($_.PowerState -eq "PoweredOn") -and ($_.ExtensionData.Summary.Runtime.MinRequiredEVCModeKey -ne $myHostEVCMode)} | Select-Object Name,@{Name='VM EVC';Expression = {$_.ExtensionData.Summary.Runtime.MinRequiredEVCModeKey}},@{Name='Host';Expression = {$EVCHost.Name}},@{Name='Host EVC';Expression = {$myHostEVCMode}},@{Name='Cluster';Expression = {$myHostEVCCluster}}
+}
+
+# Display completed array
+$EVCMismatchedVMs
+
+$PluginCategory = "vSphere"
+$Title = "EVC Mismatch"
+$Header = "EVC Mismatch"
+$Comments = "List of VMs for which the EVC mode does not match the Host/Cluster. This can negatively impact performance."
+$Display = "Table"
+$Author = "Bill Wall"
+$PluginVersion = 1.0


### PR DESCRIPTION
Created a plugin to compare the EVC mode of the VM with the EVC mode of the host/cluster. For VMs which do not match the cluster, output the VM name, VM EVC, Host name, Host EVC and Cluster name.