### PR TITLE
Fixed markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,67 +35,67 @@ This script is not to be confused with an Audit script, although the reporting f
 
 The following items are included as part of the vCheck vSphere download, they are included as vCheck Plugins and can be removed or altered very easily by editing the specific plugin file which contains the data. vCheck Plugins are found under the Plugins folder.
 
-- General Details
-- Number of Hosts
-- Number of VMs
-- Number of Templates
-- Number of Clusters
-- Number of Datastores
-- Number of Active VMs
-- Number of Inactive VMs
-- Number of DRS Migrations for the last days
-- Snapshots over x Days old
-- Datastores with less than x% free space
-- VMs created over the last x days
-- VMs removed over the last x days
-- VMs with No Tools
-- VMs with CD-Roms connected
-- VMs with Floppy Drives Connected
-- VMs with CPU ready over x%
-- VMs with over x amount of vCPUs
-- List of DRS Migrations
-- Hosts in Maintenance Mode
-- Hosts in disconnected state
-- NTP Server check for a given NTP Name
-- NTP Service check
-- vmkernel warning messages ov the last x days
-- VC Error Events over the last x days
-- VC Windows Event Log Errors for the last x days with VMware in the details
-- VC VMware Service details
-- VMs stored on datastores attached to only one host
-- VM active alerts
-- Cluster Active Alerts
-- If HA Cluster is set to use host datastore for swapfile, check the host has a swapfile location set
-- Host active Alerts
-- Dead SCSI Luns
-- VMs with over x amount of vCPUs
-- vSphere check: Slot Sizes
-- vSphere check: Outdated VM Hardware (Less than V7)
-- VMs in Inconsistent folders (the name of the folder is not the same as the name)
-- VMs with high CPU usage
-- Guest disk size check
-- Host over committing memory check
-- VM Swap and Ballooning
-- ESXi hosts without Lockdown enabled
-- ESXi hosts with unsupported mode enabled
-- General Capacity information based on CPU/MEM usage of the VMs
-- vSwitch free ports
-- Disk over commit check
-- Host configuration issues
-- VCB Garbage (left snapshots)
-- HA VM restarts and resets
-- Inaccessible VMs
-- Much, Much more.......
+-   General Details
+-   Number of Hosts
+-   Number of VMs
+-   Number of Templates
+-   Number of Clusters
+-   Number of Datastores
+-   Number of Active VMs
+-   Number of Inactive VMs
+-   Number of DRS Migrations for the last days
+-   Snapshots over x Days old
+-   Datastores with less than x% free space
+-   VMs created over the last x days
+-   VMs removed over the last x days
+-   VMs with No Tools
+-   VMs with CD-Roms connected
+-   VMs with Floppy Drives Connected
+-   VMs with CPU ready over x%
+-   VMs with over x amount of vCPUs
+-   List of DRS Migrations
+-   Hosts in Maintenance Mode
+-   Hosts in disconnected state
+-   NTP Server check for a given NTP Name
+-   NTP Service check
+-   vmkernel warning messages ov the last x days
+-   VC Error Events over the last x days
+-   VC Windows Event Log Errors for the last x days with VMware in the details
+-   VC VMware Service details
+-   VMs stored on datastores attached to only one host
+-   VM active alerts
+-   Cluster Active Alerts
+-   If HA Cluster is set to use host datastore for swapfile, check the host has a swapfile location set
+-   Host active Alerts
+-   Dead SCSI Luns
+-   VMs with over x amount of vCPUs
+-   vSphere check: Slot Sizes
+-   vSphere check: Outdated VM Hardware (Less than V7)
+-   VMs in Inconsistent folders (the name of the folder is not the same as the name)
+-   VMs with high CPU usage
+-   Guest disk size check
+-   Host over committing memory check
+-   VM Swap and Ballooning
+-   ESXi hosts without Lockdown enabled
+-   ESXi hosts with unsupported mode enabled
+-   General Capacity information based on CPU/MEM usage of the VMs
+-   vSwitch free ports
+-   Disk over commit check
+-   Host configuration issues
+-   VCB Garbage (left snapshots)
+-   HA VM restarts and resets
+-   Inaccessible VMs
+-   Much, Much more.......
 
 <a name="Enhancements">
 # Enhancements
 [*Back to top*](#Title)
 
-* **Unit Testing / CI** - We are working on full support for [Pester](https://github.com/pester/Pester/blob/master/README.md) tests, which will help automate code validation. We will start small and work to provide as much documentation as we can to help with integration.
+*   **Unit Testing / CI** - We are working on full support for [Pester](https://github.com/pester/Pester/blob/master/README.md) tests, which will help automate code validation. We will start small and work to provide as much documentation as we can to help with integration.
 
-* **Module Support** - We are looking at our options to convert some, or all of the plugins to PowerShell modules. This will make things much easier to version and track, individually. Additionally, if we convert vCheck, itself, to a module, we open our options to support publishing to the [PowerShell Gallery](https://www.powershellgallery.com/), or at least providing users and organizations a standard platform to distribute it. Again, these options are currently under review.
+*   **Module Support** - We are looking at our options to convert some, or all of the plugins to PowerShell modules. This will make things much easier to version and track, individually. Additionally, if we convert vCheck, itself, to a module, we open our options to support publishing to the [PowerShell Gallery](https://www.powershellgallery.com/), or at least providing users and organizations a standard platform to distribute it. Again, these options are currently under review.
 
-* **Settings GUI** - A settings GUI would be a basic form that would allow a user to view/set/change current vCheck configuration settings, without the complexity of settings values from within a file. This initiative is currently in development.
+*   **Settings GUI** - A settings GUI would be a basic form that would allow a user to view/set/change current vCheck configuration settings, without the complexity of settings values from within a file. This initiative is currently in development.
 
 In the meantime, don't hesitate to pop over to the [#vCheck channel on slack](https://code.vmware.com/slack/) and join in on active conversations about anything you see- or don't see- here!
 
@@ -103,41 +103,41 @@ In the meantime, don't hesitate to pop over to the [#vCheck channel on slack](ht
 # Release Notes
 [*Back to top*](#Title)
 
-* 6.22 - Fixes to VMware style. Consolidating plugins. Updates to style handling.
-* 6.21 - Added support for charts. New plugins. Support non-standard vCenter Ports. Bugfixes
-* 6.20 - First tagged release. Bugfixes. Email resource support added.
-* 6.19 - Bugfixes.
-* 6.18 - Added Job parameter to allow job specifications via XML file
-* 6.17 - Basic Internationalization (i18n) support
-* 6.16 - Table formatting rules
-* 6.15 - Added Category to all plugins and features to vCheckUtils script for Categorys.
-* 6.14 - Fixed a bug where a plugin was resetting the $VM variable so later plugins were not working :(
-* 6.13 - Fixed issue with plugins 63 and 65 not using the days
-* 6.12 - Changed Version to PluginVersion in each Plugin as the word Version is very hard to isolate!
-* 6.11 - Fixed a copy and paste mistake and plugin issues.
-* 6.10 - Fixed multiple spelling mistakes and small plugin issues
-* 6.9 - Fixed VMKernel logs but had to remove date/Time parser due to inconsistent VMKernel Log entries
-* 6.8 - Added Creator of snapshots back in due to popular demand
-* 6.7 - Added Multiple plugins from contributors - Thanks!
-* 6.6 - Tech Support Mode Plugin fixed to work with 5.0 hosts
-* 6.5 - HW Version plugin fixed due to string output
-* 6.4 - Added a 00 plugin and VeryLastPlugin for vCenter connection info to separate the report entirely from VMware if needed.
-* 6.3 - Changed the format of each Plugin so you can include a count for each header and altered plugin layout for each plugin.
-* 6.2 - Added Time to Run section based on TimeToBuild by Frederic Martin
-* 6.1 - Bug fixes, filter for ps1 files only in the plugins folder so other files can be kept in the plugins folder.
-* 6.0 - Moved plugins into seperate scripts to make it easier to expand vCheck and fixed issues + lots lots more !
-* 5.1 - Code Fixes and ability to change colour for title text to fix issue with Outlook 2007/10 not displaying correctly
-* 5.0 - Changed the order and a few titles etc, tidy up !
-* 4.9 - Added Inacessable VMs
-* 4.8 - Added HA VM restarts and resets
-* 4.7 - VMTools Issues
-* 4.6 - Added VCB Garbage
-* 4.5 - Added Host config issues
-* 4.4 - Added Disk Overcommit check
-* 4.3 - Added vSwitch free ports check
-* 4.2 - Added General Capacity Information based on CPU and MEM ussage per cluster
-* 4.1 - Added the ability to change the colours of the report.
-* 4.0 - HTML Tidy up, comments added for each item and the ability to enable/disable comments.
+*   6.22 - Fixes to VMware style. Consolidating plugins. Updates to style handling.
+*   6.21 - Added support for charts. New plugins. Support non-standard vCenter Ports. Bugfixes
+*   6.20 - First tagged release. Bugfixes. Email resource support added.
+*   6.19 - Bugfixes.
+*   6.18 - Added Job parameter to allow job specifications via XML file
+*   6.17 - Basic Internationalization (i18n) support
+*   6.16 - Table formatting rules
+*   6.15 - Added Category to all plugins and features to vCheckUtils script for Categorys.
+*   6.14 - Fixed a bug where a plugin was resetting the $VM variable so later plugins were not working :(
+*   6.13 - Fixed issue with plugins 63 and 65 not using the days
+*   6.12 - Changed Version to PluginVersion in each Plugin as the word Version is very hard to isolate!
+*   6.11 - Fixed a copy and paste mistake and plugin issues.
+*   6.10 - Fixed multiple spelling mistakes and small plugin issues
+*   6.9 - Fixed VMKernel logs but had to remove date/Time parser due to inconsistent VMKernel Log entries
+*   6.8 - Added Creator of snapshots back in due to popular demand
+*   6.7 - Added Multiple plugins from contributors - Thanks!
+*   6.6 - Tech Support Mode Plugin fixed to work with 5.0 hosts
+*   6.5 - HW Version plugin fixed due to string output
+*   6.4 - Added a 00 plugin and VeryLastPlugin for vCenter connection info to separate the report entirely from VMware if needed.
+*   6.3 - Changed the format of each Plugin so you can include a count for each header and altered plugin layout for each plugin.
+*   6.2 - Added Time to Run section based on TimeToBuild by Frederic Martin
+*   6.1 - Bug fixes, filter for ps1 files only in the plugins folder so other files can be kept in the plugins folder.
+*   6.0 - Moved plugins into seperate scripts to make it easier to expand vCheck and fixed issues + lots lots more !
+*   5.1 - Code Fixes and ability to change colour for title text to fix issue with Outlook 2007/10 not displaying correctly
+*   5.0 - Changed the order and a few titles etc, tidy up !
+*   4.9 - Added Inacessable VMs
+*   4.8 - Added HA VM restarts and resets
+*   4.7 - VMTools Issues
+*   4.6 - Added VCB Garbage
+*   4.5 - Added Host config issues
+*   4.4 - Added Disk Overcommit check
+*   4.3 - Added vSwitch free ports check
+*   4.2 - Added General Capacity Information based on CPU and MEM ussage per cluster
+*   4.1 - Added the ability to change the colours of the report.
+*   4.0 - HTML Tidy up, comments added for each item and the ability to enable/disable comments.
 
 <a name="Contributing">
 # Contributing
@@ -188,9 +188,9 @@ $PluginCategory - The Category of the plugin
 Anything that is written to stdout is included in the report. This should be either an object or hashtable in order to generate the report information.
 
 #### $Display variable
-- List
-- Table
-- Chart - Not currently merged to master
+-   List
+-   Table
+-   Chart - Not currently merged to master
 
 #### Plugin Template
   ```
@@ -253,20 +253,20 @@ Here we see the rules that apply to two different columns, with rules applied to
 Each style *must* implement a function named Get-ReportHTML, as this is what is called by vCheck to generate the HTML report.
 
 An array of plugin results is passed to Get-ReportHTML, which contains the following properties:
-* Title
-* Author
-* Version
-* Details
-* Display
-* TableFormat
-* Header
-* Comments
-* TimeToRun
+*   Title
+*   Author
+*   Version
+*   Details
+*   Display
+*   TableFormat
+*   Header
+*   Comments
+*   TimeToRun
 
 Additionally, if the style is to define colours to be used by charts, the following variables need to be defined:
-* `[string[]] $ChartColours` - Array containing HTML colours without the hash e.g. $ChartColours = @("377C2B", "0A77BA", "1D6325", "89CBE1")
-* `[string] $ChartBackground` - HTML colour without the hash. e.g. "FFFFFF"
-* `[string] $ChartSize` - YYYxZZZ formatted string - where YYY is horizontal size, and ZZZ is height. E.g. "200x200"
+*   `[string[]] $ChartColours` - Array containing HTML colours without the hash e.g. $ChartColours = @("377C2B", "0A77BA", "1D6325", "89CBE1")
+*   `[string] $ChartBackground` - HTML colour without the hash. e.g. "FFFFFF"
+*   `[string] $ChartSize` - YYYxZZZ formatted string - where YYY is horizontal size, and ZZZ is height. E.g. "200x200"
 
 To include image resources, you may call Add-ReportResource, specifying CID and data. As these are not referenced by table formatting rules, this will need to be called with the `-Used $true` parameter.
 
@@ -279,8 +279,8 @@ To include image resources, you may call Add-ReportResource, specifying CID and 
 In order to use the `-Job` parameter, an XML configuration file is used.
 
 The root element is `<vCheck>`, under this there are two elements:
-* `<globalVariables>` element specifies the path to the file containing the vCheck settings (by default globalVariables.ps1)
-* `<plugins>` element has a semi-colon separated attribute name path, which contains the path(s) to search for plugins contained in child `<plugin>` elements.
+*   `<globalVariables>` element specifies the path to the file containing the vCheck settings (by default globalVariables.ps1)
+*   `<plugins>` element has a semi-colon separated attribute name path, which contains the path(s) to search for plugins contained in child `<plugin>` elements.
 
 Each `<plugin>` element contains the plugin name.
 
@@ -344,6 +344,6 @@ If new settings or plugins have been added to the new build you will be asked to
 # More Info
 [*Back to top*](#Title)
 
-For more information please read here: http://www.virtu-al.net/vcheck-pluginsheaders/vcheck/
+For more information please read here: <http://www.virtu-al.net/vcheck-pluginsheaders/vcheck/>
 
-For an example vSphere output (doesnt contain all info) click here http://virtu-al.net/Downloads/vCheck/vCheck.htm
+For an example vSphere output (doesnt contain all info) click here <http://virtu-al.net/Downloads/vCheck/vCheck.htm>


### PR DESCRIPTION
I fixed some bugs in the markdown code that was preventing it from rendering properly.  I added a space after each HTML tag to fix headers not being interpreted correctly and ran it through a markdown linter to fix list indenting issues.