### PR TITLE
Update 98 vSwitch Security.ps1

### DIFF
--- a/Plugins/50 Network/98 vSwitch Security.ps1
+++ b/Plugins/50 Network/98 vSwitch Security.ps1
@@ -95,7 +95,7 @@ if ($VersionOK) {
         }
     }
 
-    if ($results.Host) { $results | Where-Object { ($_.AllowPromiscuous -eq $AllowPromiscuousPolicy) -or ($_.ForgedTransmits -eq $ForgedTransmitsPolicy -and $_.Type -ne "vDS Uplink Port Group") -or ($_.MacChanges -eq $MacChangesPolicy) } | Sort-Object vSwitch, PortGroup }
+    if ($results.Host) { $results | Where-Object { ($_.AllowPromiscuous -and $AllowPromiscuousPolicy) -or ($_.ForgedTransmits -and $ForgedTransmitsPolicy -and $_.Type -ne "vDS Uplink Port Group") -or ($_.MacChanges -and $MacChangesPolicy) } | Sort-Object vSwitch, PortGroup }
 }
 else {
     Write-Warning "PowerCLi version installed is lower than 5.1 Release 2"

--- a/Plugins/50 Network/98 vSwitch Security.ps1
+++ b/Plugins/50 Network/98 vSwitch Security.ps1
@@ -1,14 +1,12 @@
 $Title = "vSwitch Security"
 $Header = "vSwitch and portgroup security settings"
-$Comments = "All security options for standard vSwitches should be set to REJECT.  Distributed vSwitches may require <em>ForgedTrasmits</em> in the default portgroup but should be disabled in other VM Network portgroups unless expressly required."
+$Comments = "All security options for standard and distributed switches and port groups should be set to REJECT unless explicitly required, except for ForgedTrasmits which is required on vDS uplink port groups."
 $Display = "Table"
-$Author = "Justin Mercier, Sam McGeown, John Sneddon"
-$PluginVersion = 1.4
+$Author = "Justin Mercier, Sam McGeown, John Sneddon, Ben Hocker, Dan Barr"
+$PluginVersion = 1.5
 $PluginCategory = "vSphere"
 
 # Start of Settings
-# Enable Checking of vSwitch security settings?
-$vSwitchSecurityCheck = $true
 # Warn for AllowPromiscuous enabled?
 $AllowPromiscuousPolicy = $true
 # Warn for ForgedTransmits enabled?
@@ -18,7 +16,6 @@ $MacChangesPolicy = $true
 # End of Settings
 
 # Update settings where there is an override
-$vSwitchSecurityCheck = Get-vCheckSetting $Title "vSwitchSecurityCheck" $vSwitchSecurityCheck
 $AllowPromiscuousPolicy = Get-vCheckSetting $Title "AllowPromiscuousPolicy" $AllowPromiscuousPolicy
 $ForgedTransmitsPolicy = Get-vCheckSetting $Title "ForgedTransmitsPolicy" $ForgedTransmitsPolicy
 $MacChangesPolicy = Get-vCheckSetting $Title "MacChangesPolicy" $MacChangesPolicy
@@ -28,84 +25,82 @@ $VersionOK = $false
 
 if (((Get-PowerCLIVersion) -match "VMware.* PowerCLI (.*) build ([0-9]+)")) {
 
-   if ([int]($Matches[2]) -ge 1012425) {
-      $VersionOK = $true
-      if ([int]($Matches[2]) -ge 2548067) {
-        #PowerCLI 6+
-        if(!(Get-Module -Name VMware.VimAutomation.Vds -ErrorAction SilentlyContinue)) {
-           Import-Module VMware.VimAutomation.Vds
+    if ([int]($Matches[2]) -ge 1012425) {
+        $VersionOK = $true
+        if ([int]($Matches[2]) -ge 2548067) {
+            #PowerCLI 6+
+            if (!(Get-Module -Name VMware.VimAutomation.Vds -ErrorAction SilentlyContinue)) {
+                Import-Module VMware.VimAutomation.Vds
+            }
         }
-      }
-      else {
-        # Add required Snap-In
-        if (!(Get-PSSnapin -name VMware.VimAutomation.Vds -ErrorAction SilentlyContinue)) {
-           Add-PSSnapin VMware.VimAutomation.Vds
+        else {
+            # Add required Snap-In
+            if (!(Get-PSSnapin -name VMware.VimAutomation.Vds -ErrorAction SilentlyContinue)) {
+                Add-PSSnapin VMware.VimAutomation.Vds
+            }
         }
-      }
-   }
+    }
 }
 
 if ($VersionOK) {
-   [array] $results = $null
+    [array] $results = $null
 
-   Get-VirtualSwitch | % {
-      $Output = "" | Select-Object Host,Type,vSwitch,Portgroup,AllowPromiscuous,ForgedTransmits,MacChanges
-      if($_.ExtensionData.Summary -ne $null) {
-         $Output.Type = "vDS"
-         $Output.Host = "*"
-      } else {
-         $Output.Type = "vSS"
-         $Output.Host = $_.VMHost
-      }
-      $Output.vSwitch = $_.Name
-      $Output.Portgroup = "(none)"
-      $Output.AllowPromiscuous = ($_.Extensiondata.Config.DefaultPortConfig.SecurityPolicy.AllowPromiscuous.Value -and $_ExtensionData.Spec.Policy.Security.AllowPromiscuous)
-      $Output.ForgedTransmits = ($_.Extensiondata.Config.DefaultPortConfig.SecurityPolicy.ForgedTransmits.Value -and $_ExtensionData.Spec.Policy.Security.AllowPromiscuous)
-      $Output.MacChanges = ($_.Extensiondata.Config.DefaultPortConfig.SecurityPolicy.MacChanges.Value -and $_ExtensionData.Spec.Policy.Security.AllowPromiscuous)
-      $results += $Output
-   }
+    Get-VirtualSwitch | ForEach-Object {
+        $Output = "" | Select-Object Host, Type, vSwitch, Portgroup, AllowPromiscuous, ForgedTransmits, MacChanges
+        if ($_.ExtensionData.Summary -ne $null) {
+            $Output.Type = "vDS"
+            $Output.Host = "*"
+        }
+        else {
+            $Output.Type = "vSS"
+            $Output.Host = $_.VMHost
+        }
+        $Output.vSwitch = $_.Name
+        $Output.Portgroup = "(none)"
+        $Output.AllowPromiscuous = ($_.ExtensionData.Config.DefaultPortConfig.SecurityPolicy.AllowPromiscuous.Value -or $_.ExtensionData.Spec.Policy.Security.AllowPromiscuous)
+        $Output.ForgedTransmits = ($_.ExtensionData.Config.DefaultPortConfig.SecurityPolicy.ForgedTransmits.Value -or $_.ExtensionData.Spec.Policy.Security.ForgedTransmits)
+        $Output.MacChanges = ($_.ExtensionData.Config.DefaultPortConfig.SecurityPolicy.MacChanges.Value -or $_.ExtensionData.Spec.Policy.Security.MacChanges)
+        $results += $Output
+    }
 
-   Get-VDPortGroup | % {
-      $Output = "" | Select-Object Host,Type,vSwitch,Portgroup,AllowPromiscuous,ForgedTransmits,MacChanges
-      $Output.Host = "*"
-      $Output.Type = "vDS Port Group"
-      $Output.vSwitch = $_.VDSwitch
-      $Output.Portgroup = $_.Name
-      $Output.AllowPromiscuous = $_.Extensiondata.Config.DefaultPortConfig.SecurityPolicy.AllowPromiscuous.Value
-      $Output.ForgedTransmits = $_.Extensiondata.Config.DefaultPortConfig.SecurityPolicy.ForgedTransmits.Value
-      $Output.MacChanges = $_.Extensiondata.Config.DefaultPortConfig.SecurityPolicy.MacChanges.Value
-      $results += $Output
-   }
+    Get-VDPortGroup | ForEach-Object {
+        $Output = "" | Select-Object Host, Type, vSwitch, Portgroup, AllowPromiscuous, ForgedTransmits, MacChanges
+        $Output.Host = "*"
+        if ($_.ExtensionData.Config.Uplink -eq $true) {
+            $Output.Type = "vDS Uplink Port Group"
+        }
+        else {
+            $Output.Type = "vDS Port Group"
+        }
+        $Output.vSwitch = $_.VDSwitch
+        $Output.Portgroup = $_.Name
+        $Output.AllowPromiscuous = $_.ExtensionData.Config.DefaultPortConfig.SecurityPolicy.AllowPromiscuous.Value
+        $Output.ForgedTransmits = $_.ExtensionData.Config.DefaultPortConfig.SecurityPolicy.ForgedTransmits.Value
+        $Output.MacChanges = $_.ExtensionData.Config.DefaultPortConfig.SecurityPolicy.MacChanges.Value
+        $results += $Output
+    }
 
-   $VMH | Where-Object { $_.ConnectionState -eq "Connected" } | % {
-      $VMHost = $_
-      Get-VirtualPortGroup -VMHost $_ -Standard | % {
-         $Output = "" | Select-Object Host,Type,vSwitch,Portgroup,AllowPromiscuous,ForgedTransmits,MacChanges
-         $Output.Host = $VMHost.Name
-         $Output.Type = "vSS Port Group"
-         $Output.vSwitch = $_.VirtualSwitch
-         $Output.Portgroup = $_.Name
-         $Output.AllowPromiscuous = $_.ExtensionData.Spec.Policy.Security.AllowPromiscuous -and ($portgroup.Spec.Policy.Security.MacChanges -eq $null)
-         $Output.ForgedTransmits = $_.ExtensionData.Spec.Policy.Security.ForgedTransmits -and ($portgroup.Spec.Policy.Security.MacChanges -eq $null)
-         $Output.MacChanges = $_.Spec.ExtensionData.Policy.Security.MacChanges -and ($portgroup.Spec.Policy.Security.MacChanges -eq $null)
-         $results += $Output
-      }
-   }
+    $VMH | Where-Object { $_.ConnectionState -eq "Connected" } | ForEach-Object {
+        $VMHost = $_
+        Get-VirtualPortGroup -VMHost $_ -Standard | ForEach-Object {
+            $Output = "" | Select-Object Host, Type, vSwitch, Portgroup, AllowPromiscuous, ForgedTransmits, MacChanges
+            $Output.Host = $VMHost.Name
+            $Output.Type = "vSS Port Group"
+            $Output.vSwitch = $_.VirtualSwitch
+            $Output.Portgroup = $_.Name
+            $Output.AllowPromiscuous = $_.ExtensionData.Spec.Policy.Security.AllowPromiscuous -and ($_.Spec.Policy.Security.AllowPromiscuous -eq $null)
+            $Output.ForgedTransmits = $_.ExtensionData.Spec.Policy.Security.ForgedTransmits -and ($_.Spec.Policy.Security.ForgedTransmits -eq $null)
+            $Output.MacChanges = $_.ExtensionData.Spec.Policy.Security.MacChanges -and ($_.Spec.Policy.Security.MacChanges -eq $null)
+            $results += $Output
+        }
+    }
 
-   if ($results.Host) { $results | Where-Object { ($_.AllowPromiscuous -eq $AllowPromiscuousPolicy) -or ($_.ForgedTransmits -eq $ForgedTransmitsPolicy) -or ($_.MacChanges -eq $MacChangesPolicy) } | Sort-Object vSwitch,PortGroup }
+    if ($results.Host) { $results | Where-Object { ($_.AllowPromiscuous -eq $AllowPromiscuousPolicy) -or ($_.ForgedTransmits -eq $ForgedTransmitsPolicy -and $_.Type -ne "vDS Uplink Port Group") -or ($_.MacChanges -eq $MacChangesPolicy) } | Sort-Object vSwitch, PortGroup }
 }
 else {
-   Write-Warning "PowerCLi version installed is lower than 5.1 Release 2"
-   New-Object PSObject -Property @{"Message"="PowerCLi version installed is lower than 5.1 Release 2, please update to use this plugin"}
+    Write-Warning "PowerCLi version installed is lower than 5.1 Release 2"
+    New-Object PSObject -Property @{"Message" = "PowerCLi version installed is lower than 5.1 Release 2, please update to use this plugin"}
 }
-
-$Title = "vSwitch Security"
-$Header = "vSwitch and portgroup security settings"
-$Comments = "All security options for standard vSwitches should be set to REJECT.  Distributed vSwitches may require <em>ForgedTrasmits</em> in the default portgroup but should be disabled in other VM Network portgroups unless expressly required."
-$Display = "Table"
-$Author = "Justin Mercier, Sam McGeown, John Sneddon, Ben Hocker"
-$PluginVersion = 1.3
-$PluginCategory = "vSphere"
 
 # Changelog
 ## 1.0 : Initial Release
@@ -113,4 +108,4 @@ $PluginCategory = "vSphere"
 ## 1.2 : Added version check (Issue #71)
 ## 1.3 : Add Get-vCheckSetting
 ## 1.4 : Fix Version checking for PowerCLI 6.5 - vSphere is no longer in the product name (Issue #514)
-
+## 1.5 : Ignore ForgedTransmits on vDS Uplink port groups, removed redundant plugin variable block, fixed logic bugs


### PR DESCRIPTION
A number of logical and formatting fixes to this plugin:
1. Ignore ForgedTransmits on vDS Uplink port groups.
2. Expanded ForEach-Object aliases and ran thru VS Code's formatter.
3. Fixed several logic bugs which prevented some checks from returning expected results.
4. Removed unused $vSwitchSecurityCheck setting and redundant plugin variable block.
5. Fixed the settings logic so a vSwitch or port group only appears if one of the conditions you've selected to report on is true.