### PR TITLE
Update some host plugins to report connected hosts only

### DIFF
--- a/Plugins/30 Host/29 AD Authentication.ps1
+++ b/Plugins/30 Host/29 AD Authentication.ps1
@@ -1,3 +1,11 @@
+$Title = "Active Directory Authentication"
+$Header = "Active Directory Authentication"
+$Comments = "Active Directory configuration and status for each host. (Domain: $ADDomainName, Admin Group: $ADAdminGroup, Display all results: $ADDisplayOK)"
+$Display = "Table"
+$Author = "Bill Wall, Dan Barr"
+$PluginVersion = 1.2
+$PluginCategory = "vSphere"
+
 # Start of Settings
 # Show "OK" results?
 $ADDisplayOK = $false
@@ -11,18 +19,18 @@ $ADAdminGroup = "ESX Admins"
 $ADFailedHosts = @()
 $ADOKHosts = @()
 
-ForEach ($ADHost in $VMH) {
-		# Get authetication settings
-		$myADAuth = $ADHost | Get-VMHostAuthentication
-		# Get Admin Group settings
-		$myADGroup = ($ADHost | Get-AdvancedSetting -Name "Config.HostAgent.plugins.hostsvc.esxAdminsGroup").Value
-		# Build array item
-		$myADHost = $ADHost | Select-Object Name,@{Name='Domain';Expression = {$myADAuth.Domain}},@{Name='MembershipStatus';Expression = {$myADAuth.DomainMembershipStatus}},@{Name='AdminGroup';Expression = {$myADGroup}}
-		# Iterate tests, a single failure constitues a failure for the unit
-		If ($myADAuth.Domain -ne $ADDomainName) {$ADFailedHosts += $myADHost } #Configured domain does not equal expected
-		ElseIf ($myADGroup -ne $ADAdminGroup) {$ADFailedHosts += $myADHost} #Configured Admin Group does not equal expected
-		ElseIf ($myADAuth.DomainMembershipStatus -ne "OK") {$ADFailedHosts += $myADHost} #Domain Memebership is in doubt
-		Else {$ADOKHosts += $myADHost} #Configuration passed all tests
+ForEach ($ADHost in $VMH | Where-Object {$_.Connectionstate -eq "Connected"}) {
+	# Get authetication settings
+	$myADAuth = $ADHost | Get-VMHostAuthentication
+	# Get Admin Group settings
+	$myADGroup = ($ADHost | Get-AdvancedSetting -Name "Config.HostAgent.plugins.hostsvc.esxAdminsGroup").Value
+	# Build array item
+	$myADHost = $ADHost | Select-Object Name,@{Name='Domain';Expression = {$myADAuth.Domain}},@{Name='MembershipStatus';Expression = {$myADAuth.DomainMembershipStatus}},@{Name='AdminGroup';Expression = {$myADGroup}}
+	# Iterate tests, a single failure constitues a failure for the unit
+	If ($myADAuth.Domain -ne $ADDomainName) {$ADFailedHosts += $myADHost } #Configured domain does not equal expected
+	ElseIf ($myADGroup -ne $ADAdminGroup) {$ADFailedHosts += $myADHost} #Configured Admin Group does not equal expected
+	ElseIf ($myADAuth.DomainMembershipStatus -ne "OK") {$ADFailedHosts += $myADHost} #Domain Memebership is in doubt
+	Else {$ADOKHosts += $myADHost} #Configuration passed all tests
 }
 
 # If desired, add OK hosts to display after failed hosts
@@ -31,10 +39,5 @@ If ($ADDisplayOK) {$ADFailedHosts += $ADOKHosts}
 # Provide output
 $ADFailedHosts
 
-$PluginCategory = "vSphere"
-$Title = "Active Directory Authentication"
-$Header = "Active Directory Authentication"
-$Comments = "Active Directory configuration and status for each host. (Domain: $ADDomainName, Admin Group: $ADAdminGroup, Display all results: $ADDisplayOK)"
-$Display = "Table"
-$Author = "Bill Wall"
-$PluginVersion = 1.1
+# Changelog
+## 1.2 : Only check Connected hosts since Disconnected and Not Responding produce empty data

--- a/Plugins/30 Host/31 NTP Name and Service.ps1
+++ b/Plugins/30 Host/31 NTP Name and Service.ps1
@@ -2,13 +2,16 @@ $Title = "NTP Name and Service"
 $Header = "NTP Issues: [count]"
 $Comments = "The following hosts do not have the correct NTP settings and may cause issues if the time becomes far apart from the vCenter/Domain or other hosts"
 $Display = "Table"
-$Author = "Alan Renouf"
-$PluginVersion = 1.2
+$Author = "Alan Renouf, Dan Barr"
+$PluginVersion = 1.3
 $PluginCategory = "vSphere"
 
-# Start of Settings 
+# Start of Settings
 # The NTP server which should be set on your hosts (comma-separated)
 $ntpserver = "pool.ntp.org,pool2.ntp.org"
 # End of Settings
 
-$VMH | Where-Object {$_.Connectionstate -ne "Disconnected"} | Select-Object Name, @{N="NTPServer";E={($_ | Get-VMHostNtpServer) -join ","}}, @{N="ServiceRunning";E={(Get-VmHostService -VMHost $_ | Where-Object {$_.key -eq "ntpd"}).Running}} | Where-Object {$_.ServiceRunning -eq $false -or $_.NTPServer -ne $ntpserver}
+$VMH | Where-Object {$_.Connectionstate -eq "Connected"} | Select-Object Name, @{N="NTPServer";E={($_ | Get-VMHostNtpServer) -join ","}}, @{N="ServiceRunning";E={(Get-VmHostService -VMHost $_ | Where-Object {$_.key -eq "ntpd"}).Running}} | Where-Object {$_.ServiceRunning -eq $false -or $_.NTPServer -ne $ntpserver}
+
+# Changelog
+## 1.3 : Only check Connected hosts since Disconnected and Not Responding produce empty data

--- a/Plugins/30 Host/35 Host Configuration Issues.ps1
+++ b/Plugins/30 Host/35 Host Configuration Issues.ps1
@@ -2,24 +2,27 @@ $Title = "Host Configuration Issues"
 $Header = "Host(s) Config Issue(s): [count]"
 $Comments = "The following configuration issues have been registered against Hosts in vCenter"
 $Display = "Table"
-$Author = "Alan Renouf"
-$PluginVersion = 1.1
+$Author = "Alan Renouf, Dan Barr"
+$PluginVersion = 1.2
 $PluginCategory = "vSphere"
 
-# Start of Settings 
-# End of Settings 
+# Start of Settings
+# End of Settings
 
 $hostcialarms = @()
-foreach ($HostsView in $HostsViews) {
-   if ($HostsView.ConfigIssue) {           
-      $HostConfigIssues = $HostsView.ConfigIssue
-      Foreach ($HostConfigIssue in $HostConfigIssues) {
-         $Details = "" | Select-Object Name, Message
-         $Details.Name = $HostsView.name
-         $Details.Message = $HostConfigIssue.FullFormattedMessage
-         $hostcialarms += $Details
-      }
-   }
+foreach ($HostsView in $HostsViews | Where-Object {$_.Summary.Runtime.ConnectionState -eq 'connected'}) {
+    if ($HostsView.ConfigIssue) {
+        $HostConfigIssues = $HostsView.ConfigIssue
+        Foreach ($HostConfigIssue in $HostConfigIssues) {
+            $Details = "" | Select-Object Name, Message
+            $Details.Name = $HostsView.name
+            $Details.Message = $HostConfigIssue.FullFormattedMessage
+            $hostcialarms += $Details
+        }
+    }
 }
 
 $hostcialarms | Sort-Object name
+
+# Changelog
+## 1.2 : Only check Connected hosts since Disconnected and Not Responding hosts produce an error


### PR DESCRIPTION
Fix several plugins which report empty results or errors when hosts are disconnected or not responding. Also normalized some indenting.