### PR TITLE
Add host plugin to detect evaluation licenses

### DIFF
--- a/Plugins/30 Host/130 Eval License Key.ps1
+++ b/Plugins/30 Host/130 Eval License Key.ps1
@@ -1,0 +1,22 @@
+$Title = "Eval License Keys"
+$Comments = "The following hosts are using an evaluation key that will expire, causing them to disconnect from vCenter."
+$Display = "Table"
+$Author = "Doug Taliaferro"
+$PluginVersion = 1.0
+$PluginCategory = "vSphere"
+
+# Start of Settings
+# End of Settings
+
+$hostResults = @()
+foreach ($esxhost in ($VMH | where {$_.ConnectionState -match "Connected|Maintenance"})) {
+    if ($esxhost.LicenseKey -eq "00000-00000-00000-00000-00000") {
+        $myObj = "" | Select VMHost, LicenseKey
+        $myObj.VMHost = $esxhost.Name
+        $myObj.LicenseKey = $esxhost.LicenseKey
+        $hostResults += $myObj
+	}
+}
+$hostResults
+
+$Header = "Hosts using an Evaluation Key : [count]"


### PR DESCRIPTION
Lists hosts that are not licensed and will disconnect from vCenter when the evaluation period expires.