### PR TITLE
Fix "\Lang" directory casing

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -37,7 +37,7 @@ $pLang = DATA {
 '@
 }
 # Override the default (en) if it exists in lang directory
-Import-LocalizedData -BaseDirectory ($ScriptPath + "\lang") -BindingVariable pLang -ErrorAction SilentlyContinue
+Import-LocalizedData -BaseDirectory ($ScriptPath + "\Lang") -BindingVariable pLang -ErrorAction SilentlyContinue
 
 # Find the VI Server and port from the global settings file
 $VIServer = ($Server -Split ":")[0]

--- a/Plugins/20 Cluster/10 HA Configuration Issues.ps1
+++ b/Plugins/20 Cluster/10 HA Configuration Issues.ps1
@@ -33,7 +33,7 @@ $pLang = DATA {
 '@
 }
 # Override the default (en) if it exists in lang directory
-Import-LocalizedData -BaseDirectory ($ScriptPath + "\lang") -BindingVariable pLang -ErrorAction SilentlyContinue
+Import-LocalizedData -BaseDirectory ($ScriptPath + "\Lang") -BindingVariable pLang -ErrorAction SilentlyContinue
 
 # Clusters with HA disabled
 $HAIssues = @()

--- a/Plugins/30 Host/07 Hosts Overcommit State.ps1
+++ b/Plugins/30 Host/07 Hosts Overcommit State.ps1
@@ -21,7 +21,7 @@ $pLang = DATA {
 '@
 }
 # Override the defaults (en) if language file exists in lang driectory
-Import-LocalizedData -BaseDirectory ($ScriptPath + "\lang") -BindingVariable pLang -ErrorAction SilentlyContinue
+Import-LocalizedData -BaseDirectory ($ScriptPath + "\Lang") -BindingVariable pLang -ErrorAction SilentlyContinue
 
 $OverCommit = @()
 $i = 0

--- a/Plugins/60 VM/32 VM CPU Percent RDY.ps1
+++ b/Plugins/60 VM/32 VM CPU Percent RDY.ps1
@@ -18,7 +18,7 @@ $pLang = DATA {
 }
 
 # Override the default (en) if it exists in lang directory
-Import-LocalizedData -BaseDirectory ($ScriptPath + "\lang") -BindingVariable pLang -ErrorAction SilentlyContinue
+Import-LocalizedData -BaseDirectory ($ScriptPath + "\Lang") -BindingVariable pLang -ErrorAction SilentlyContinue
 
 # Update settings where there is an override
 $PercCPUReady = Get-vCheckSetting $Title "PercCPUReady" $PercCPUReady

--- a/Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1
+++ b/Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1
@@ -3,10 +3,10 @@
 #                             Internationalization                             #
 ################################################################################
 # Default language en-US
-Import-LocalizedData -BaseDirectory ($ScriptPath + '\lang') -BindingVariable pLang -UICulture en-US -ErrorAction SilentlyContinue
+Import-LocalizedData -BaseDirectory ($ScriptPath + '\Lang') -BindingVariable pLang -UICulture en-US -ErrorAction SilentlyContinue
 
 # Override the default (en-US) if it exists in lang directory
-Import-LocalizedData -BaseDirectory ($ScriptPath + "\lang") -BindingVariable pLang -ErrorAction SilentlyContinue
+Import-LocalizedData -BaseDirectory ($ScriptPath + "\Lang") -BindingVariable pLang -ErrorAction SilentlyContinue
 
 #endregion Internationalization
 

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -80,10 +80,10 @@ $PluginsFolder = $ScriptPath + "\Plugins\"
 #                             Internationalization                             #
 ################################################################################
 # Default language en-US
-Import-LocalizedData -BaseDirectory ($ScriptPath + '\lang') -BindingVariable lang -UICulture en-US -ErrorAction SilentlyContinue
+Import-LocalizedData -BaseDirectory ($ScriptPath + '\Lang') -BindingVariable lang -UICulture en-US -ErrorAction SilentlyContinue
 
 # Override the default (en-US) if it exists in lang directory
-Import-LocalizedData -BaseDirectory ($ScriptPath + "\lang") -BindingVariable lang -ErrorAction SilentlyContinue
+Import-LocalizedData -BaseDirectory ($ScriptPath + "\Lang") -BindingVariable lang -ErrorAction SilentlyContinue
 
 #endregion Internationalization
 


### PR DESCRIPTION
Both Linux and MacOS have case-sensitive filenames.

This fixes the casing of the "\Lang" directory where it's referenced. While it does silently continue there are immediate errors when running `-Config` because of this line: https://github.com/alanrenouf/vCheck-vSphere/blob/dev/vCheck.ps1#L833