### PR TITLE
Fix LinkedResource with non-native paths

### DIFF
--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -631,7 +631,7 @@ function Get-ReportResource {
 				}
 				if ($ReturnType -eq "linkedresource") {
 					# return a linked resource to be added to mail message
-					$lr = New-Object system.net.mail.LinkedResource($data[1])
+					$lr = New-Object system.net.mail.LinkedResource(Convert-Path $data[1])
 					$lr.ContentId = $cid
 					return $lr;
 				}


### PR DESCRIPTION
system.net.mail.LinkedResource doesn't like non-native paths such as backslashes on Linux. The Convert-Path cmdlet fixes that.