### PR TITLE
Plugin 121 BusSharingMode. Fixed bug where it would mess up plugins that came after it

### DIFF
--- a/Plugins/60 VM/121 BusSharingMode - Physical and Virtual.ps1
+++ b/Plugins/60 VM/121 BusSharingMode - Physical and Virtual.ps1
@@ -2,18 +2,18 @@ $Title = "BusSharingMode - Physical and Virtual"
 $Header = "BusSharingMode - Physical and Virtual: [count]"
 $Comments = "The following VMs have physical and/or virtual bus sharing. A problem will occur in case of svMotion without reconfiguration of the applications which are using these virtual disks and also change of the VM configuration concerned."
 $Display = "Table"
-$Author = "Petar Enchev, Luc Dekens"
-$PluginVersion = 1.0
+$Author = "Petar Enchev, Luc Dekens, Fabio Freire"
+$PluginVersion = 1.1
 $PluginCategory = "vSphere"
 
 # Start of Settings
 # End of Settings
 
 # BusSharingMode - Physical and Virtual
-ForEach ($vm in $FullVM){
-    $scsi = $vm.Config.Hardware.Device | Where-Object {$_ -is [VMware.Vim.VirtualSCSIController] -and ($_.SharedBus -eq "physicalSharing" -or $_.SharedBus -eq "virtualSharing")}
+ForEach ($Object in $FullVM){
+    $scsi = $Object.Config.Hardware.Device | Where-Object {$_ -is [VMware.Vim.VirtualSCSIController] -and ($_.SharedBus -eq "physicalSharing" -or $_.SharedBus -eq "virtualSharing")}
     if ($scsi){
-        $scsi | Select-Object @{N="VM";E={$vm.Name}},
+        $scsi | Select-Object @{N="VM";E={$Object.Name}},
             @{N="Controller";E={$_.DeviceInfo.Label}},
             @{N="BusSharingMode";E={$_.SharedBus}}
     }
@@ -21,3 +21,4 @@ ForEach ($vm in $FullVM){
 
 # Changelog
 ## 1.0 : Initial Version
+## 1.1 : Fixed bug where it would mess up plugins that came after it 


### PR DESCRIPTION
This plugin changes the $VM variable, thereby rendering it unusable to plugins that are executed after it. I've simply renamed $VM to $Object