### PR TITLE
Fix for special characters in cluster name

### DIFF
--- a/Plugins/20 Cluster/71 Capacity Planning.ps1
+++ b/Plugins/20 Cluster/71 Capacity Planning.ps1
@@ -3,7 +3,7 @@ $Header = "QuickStats Capacity Planning"
 $Comments = "The following gives brief capacity information for each cluster based on QuickStats CPU/Mem usage and counting for HA failover requirements"
 $Display = "Table"
 $Author = "Raphael Schitz, Frederic Martin"
-$PluginVersion = 1.7
+$PluginVersion = 1.8
 $PluginCategory = "vSphere"
 
 
@@ -18,6 +18,7 @@ $limitResourceMEMClusNonHA = 0.6
 $limitResourceCPUClusNonHA = Get-vCheckSetting $Title "limitResourceCPUClusNonHA" $limitResourceCPUClusNonHA
 $limitResourceMEMClusNonHA = Get-vCheckSetting $Title "limitResourceMEMClusNonHA" $limitResourceMEMClusNonHA
 
+Add-Type -AssemblyName System.Web
 $capacityinfo = @()
 foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort-Object Name)) {
    
@@ -45,10 +46,10 @@ foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort
    $CluMemUsage = (get-view $cluv.ResourcePool).Summary.runtime.memory.OverallUsage
    $CluMemUsageAvg = $CluMemUsage/1MB
    if ($cluvmlist -and $cluv.host -and $CluMemUsageAvg -gt 100){
-      $VmMemAverage = $CluMemUsageAvg/(Get-Cluster $cluv.name|Get-VM).count
+      $VmMemAverage = $CluMemUsageAvg/(Get-Cluster -Id $cluv.MoRef|Get-VM).count
       $MemVmLeft = [math]::round(($DasRealMemCapacity-$CluMemUsageAvg)/$VmMemAverage,0)
    }
-   elseif ($CluMemUsageAvg -lt 100) {$CluMemUsageAvg = "N/A"}
+   elseif ($CluMemUsageAvg -lt 100) {$MemVmLeft = "N/A"}
    else{$MemVmLeft = 0}
 
    # vCPU to pCPU ratio
@@ -64,7 +65,7 @@ foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort
 
    $clucapacity = [PSCustomObject] @{
       Datacenter = (Get-VIObjectByVIView -MoRef $cluv.Parent).Parent.Name
-      ClusterName = $cluv.name
+      ClusterName = [System.Web.HttpUtility]::UrlDecode($cluv.name)
       "Estimated Num VM Left (CPU)" = $CpuVmLeft
       "Estimated Num VM Left (MEM)" = $MemVmLeft
       "vCPU/pCPU ratio" =  $vCPUpCPUratio
@@ -75,3 +76,7 @@ foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort
 }
 
 $capacityinfo | Sort-Object Datacenter, ClusterName
+
+# Changelog
+## 1.8 : Use 'Get-Cluster -Id' and [System.Web.HttpUtility]::UrlDecode to handle special characters in cluster name.
+##       Fix bug where $MemVmLeft was not getting reset and displays value from previous cluster.


### PR DESCRIPTION
This is a proposal to fix #634.  It also addresses a bug where $MemVmLeft was not being set for clusters with very low memory usage.