### PR TITLE
71 Capacity Planning. pCPU thread vs core fix

### DIFF
--- a/Plugins/20 Cluster/71 Capacity Planning.ps1
+++ b/Plugins/20 Cluster/71 Capacity Planning.ps1
@@ -54,7 +54,8 @@ foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort
 
    # vCPU to pCPU ratio
    if ($cluvmlist){
-      $vCPUpCPUratio = ("1:{0}" -f [math]::round(($cluvmlist|Measure-Object -Sum -Property NumCpu).sum / $cluv.summary.NumCpuThreads,1))
+      $vCPUCPUthreadratio = ("1:{0}" -f [math]::round(($cluvmlist|Measure-Object -Sum -Property NumCpu).sum / $cluv.summary.NumCpuThreads,1))
+	   $vCPUpCPUratio = ("1:{0}" -f [math]::round(($cluvmlist|Measure-Object -Sum -Property NumCpu).sum / $cluv.summary.NumCpuCores,1))
       $VMVMHostRatio = ("1:{0}" -f [math]::round(($cluvmlist).count/$cluv.Summary.NumHosts,1))
    }
    else 
@@ -68,7 +69,8 @@ foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort
       ClusterName = [System.Web.HttpUtility]::UrlDecode($cluv.name)
       "Estimated Num VM Left (CPU)" = $CpuVmLeft
       "Estimated Num VM Left (MEM)" = $MemVmLeft
-      "vCPU/pCPU ratio" =  $vCPUpCPUratio
+      "vCPU/pCPU Core ratio" =  $vCPUpCPUratio
+	   "vCPU/pCPU Thread ratio" =  $vCPUCPUthreadratio
       "VM/VMHost ratio" = $VMVMHostRatio
    }
    


### PR DESCRIPTION
VMware recommends using pCPU cores for ratio calculations, not vCPU threads. (https://communities.vmware.com/thread/572025)
I changed the calculation to include both and edited the descriptions to match.

Fix for issue #676