### PR TITLE
Fix for empty $Ignore strings

### DIFF
--- a/Plugins/10 vCenter/47 vCenter Session Age.ps1
+++ b/Plugins/10 vCenter/47 vCenter Session Age.ps1
@@ -23,7 +23,7 @@ $vCenterSessionsDoNotInclude = Get-vCheckSetting $Title "vCenterSessionsDoNotInc
 
 (Get-View $ServiceInstance.Content.SessionManager).SessionList | `
    Where-Object {$_.LoginTime -lt (Get-Date).AddHours(-$MaxvCenterSessionAge) -AND `
-   $_.UserName -notmatch $vCenterSessionsDoNotInclude} | `
+   ($vCenterSessionsDoNotInclude -eq "" -or $_.UserName -notmatch $vCenterSessionsDoNotInclude)} | `
    Select-Object LoginTime, UserName, FullName, @{N="IdleMinutes";e={([Math]::Round(((Get-Date)-($_.lastActiveTime).ToLocalTime()).TotalMinutes))}} | ` 
    Where-Object {$_.IdleMinutes -ge $MinvCenterSessionAge}
 

--- a/Plugins/20 Cluster/10 HA Configuration Issues.ps1
+++ b/Plugins/20 Cluster/10 HA Configuration Issues.ps1
@@ -37,7 +37,7 @@ Import-LocalizedData -BaseDirectory ($ScriptPath + "\Lang") -BindingVariable pLa
 
 # Clusters with HA disabled
 $HAIssues = @()
-$HAIssues += $Clusters | Where-Object {$_.Name -notmatch $ClustersDoNotInclude -and $_.HAEnabled -ne $CLusterHAShouldBeEnabled } |
+$HAIssues += $Clusters | Where-Object {($ClustersDoNotInclude -eq "" -or $_.Name -notmatch $ClustersDoNotInclude) -and $_.HAEnabled -ne $CLusterHAShouldBeEnabled } |
   Select-Object @{Name="Cluster";Expression={$_.Name}},@{Name="Configuration Issue";Expression={$pLang.HADisabled}}
 
 # Clusters with host monitoring disabled 

--- a/Plugins/20 Cluster/52 Datastore Consistency.ps1
+++ b/Plugins/20 Cluster/52 Datastore Consistency.ps1
@@ -19,7 +19,7 @@ if ($Clusters -ne $null)
    ForEach ($Cluster in ($Clusters)) 
    {
       $Cluster.ExtensionData.Host | Foreach-Object { $h = $_; $Datastores | Where-Object {$_.ExtensionData.Host.key -contains $h}} | 
-         Where-Object {$_.Name -notmatch $DSDoNotInclude } | Group-Object Name | Where-Object { $_.Count -ne $cluster.ExtensionData.Host.count } | 
+         Where-Object {($DSDoNotInclude -eq "" -or $_.Name -notmatch $DSDoNotInclude) } | Group-Object Name | Where-Object { $_.Count -ne $cluster.ExtensionData.Host.count } | 
          Select-Object @{Name="Name"; Expression={$_.Group.name}}, @{Name="Cluster";Expression={$Cluster.Name}}
    }
 }

--- a/Plugins/20 Cluster/55 Clusters with DRS Disabled.ps1
+++ b/Plugins/20 Cluster/55 Clusters with DRS Disabled.ps1
@@ -15,6 +15,6 @@ $ClustersDoNotInclude = "VM1_*|VM2_*"
 $ClustersDoNotInclude = Get-vCheckSetting $Title "ClustersDoNotInclude" $ClustersDoNotInclude
 
 @( $Clusters |
-   Where-Object {$_.Name -notmatch $ClustersDoNotInclude -and -not $_.DRSEnabled} |
+   Where-Object {($ClustersDoNotInclude -eq "" -or $_.Name -notmatch $ClustersDoNotInclude) -and -not $_.DRSEnabled} |
    Select-Object -Property Name,DRSEnabled
 )

--- a/Plugins/20 Cluster/75 DRS Rules.ps1
+++ b/Plugins/20 Cluster/75 DRS Rules.ps1
@@ -29,7 +29,7 @@ if ($ShowVMAntiAffinity) { $Types += "VMAntiAffinity"}
 if ($ShowHostAffinity)   { $Types += "VMHostAffinity"}
 
 $Clusters | Foreach-Object {
-   Get-DrsRule -Cluster $_ -Type $Types | Where-Object { $_.Name -notmatch $excludeName } | 
+   Get-DrsRule -Cluster $_ -Type $Types | Where-Object { ($excludeName -eq "" -or $_.Name -notmatch $excludeName) } | 
    Select-Object Cluster, Enabled, Name, Type, @{N="VM";E={(Get-View $_.VMIDS | Select-Object -ExpandProperty Name) -join "<br />"}},
      @{N="Rule Host";E={(Get-View $_.AffineHostIds | Select-Object -ExpandProperty Name) -join "<br />" }},
      @{N="Running on";E={(Get-View (Get-View $_.VMIDS | Foreach-Object {$_.Runtime.Host}) | Select-Object ExpandProperty Name) -join "<br />"}}

--- a/Plugins/40 Datastore/03 Datastore Information.ps1
+++ b/Plugins/40 Datastore/03 Datastore Information.ps1
@@ -16,7 +16,7 @@ $DatastoreIgnore = "local"
 $DatastoreSpace = Get-vCheckSetting $Title "DatastoreSpace" $DatastoreSpace
 $DatastoreIgnore = Get-vCheckSetting $Title "DatastoreIgnore" $DatastoreIgnore
 
-$Datastores | Where-Object {$_.Name -notmatch $DatastoreIgnore} | Select-Object Name, Type, @{N="CapacityGB";E={[math]::Round($_.CapacityGB,2)}}, @{N="FreeSpaceGB";E={[math]::Round($_.FreeSpaceGB,2)}}, PercentFree| Sort-Object PercentFree | Where-Object { $_.PercentFree -lt $DatastoreSpace }
+$Datastores | Where-Object {($DatastoreIgnore -eq "" -or $_.Name -notmatch $DatastoreIgnore)} | Select-Object Name, Type, @{N="CapacityGB";E={[math]::Round($_.CapacityGB,2)}}, @{N="FreeSpaceGB";E={[math]::Round($_.FreeSpaceGB,2)}}, PercentFree| Sort-Object PercentFree | Where-Object { $_.PercentFree -lt $DatastoreSpace }
 
 $Header = "Datastores (Less than $DatastoreSpace% Free) : [count]"
 

--- a/Plugins/40 Datastore/109 Orphaned VMDK File.ps1.disabled
+++ b/Plugins/40 Datastore/109 Orphaned VMDK File.ps1.disabled
@@ -49,7 +49,7 @@ $report = @()
 $arrUsedDisks = $FullVM | % {$_.Layout} | % {$_.Disk} | % {$_.DiskFile}
 
 #Write-CustomOut "..filtering list to exclude datastores that match this regex pattern: $excludeDatastoreRegex"
-$arrDS = $storageviews | Sort-Object -property Name | Where-Object {$_.name -notmatch $excludeDatastoreRegex }
+$arrDS = $storageviews | Sort-Object -property Name | Where-Object {($excludeDatastoreRegex -eq "" -or $_.name -notmatch $excludeDatastoreRegex) }
 
 foreach ($strDatastore in $arrDS) {
    # Write-CustomOut "..$($strDatastore.Name) Orphaned Disks:"
@@ -68,7 +68,7 @@ foreach ($strDatastore in $arrDS) {
 
    foreach ($folder in $searchResult)
    {
-      if ($folder.FolderPath -notmatch $excludeVMPathRegex)
+      if (($excludeVMPathRegex -eq "" -or $folder.FolderPath -notmatch $excludeVMPathRegex))
       {
          foreach ($fileResult in $folder.File)
          {
@@ -97,7 +97,7 @@ foreach ($strDatastore in $arrDS) {
                } # end of if (-not ($arrUsedDisks -contains ($folder.FolderPath + $fileResult.Path)))
             } # end of if ($fileResult.Path)
          } # end of foreach ($fileResult in $folder.File)
-      } # end of if ($folder.FolderPath -notmatch $excludeVMPathRegex)
+      } # end of if ($excludeVMPathRegex -eq "" -or $folder.FolderPath -notmatch $excludeVMPathRegex)
    } # end of foreach ($folder in $searchResult)
 } # end of foreach ($strDatastore in $arrDS)
 

--- a/Plugins/40 Datastore/116 sDRS VM Behavior not Default.ps1
+++ b/Plugins/40 Datastore/116 sDRS VM Behavior not Default.ps1
@@ -16,7 +16,7 @@ $ExcludedVMs = Get-vCheckSetting $Title "ExcludedVMs" $ExcludedVMs
 
 $DatastoreClustersView | Foreach-Object {$_.PodStorageDrsEntry.StorageDrsConfig.VMConfig} | `
    Where-Object {$_.Enabled -eq $false -or $_.Behavior -ne $null} | `
-   Select-Object @{N="VM";E={Get-View $_.Vm | Select-Object -ExpandProperty Name}}, Enabled, Behavior,@{N="Datastore Cluster";E={$dc.Name}} | Where-Object { $_.VM -notmatch $ExcludedVMs }
+   Select-Object @{N="VM";E={Get-View $_.Vm | Select-Object -ExpandProperty Name}}, Enabled, Behavior,@{N="Datastore Cluster";E={$dc.Name}} | Where-Object { ($ExcludedVMs -eq "" -or $_.VM -notmatch $ExcludedVMs) }
 
 # Changelog
 ## 1.0 : Initial Version

--- a/Plugins/40 Datastore/34 Number of VMs per Datastore.ps1
+++ b/Plugins/40 Datastore/34 Number of VMs per Datastore.ps1
@@ -16,7 +16,7 @@ $ExcludedDatastores = "ExcludeMe"
 $NumVMsPerDatastore = Get-vCheckSetting $Title "NumVMsPerDatastore" $NumVMsPerDatastore
 $ExcludedDatastores = Get-vCheckSetting $Title "ExcludedDatastores" $ExcludedDatastores
 
-$StorageViews | Where-Object { $_.Name -notmatch $ExcludedDatastores } | Select-Object Name, @{N="NumVM";E={($_.vm).Count}} | Where-Object { $_.NumVM -gt $NumVMsPerDatastore} | Sort-Object NumVM -Descending
+$StorageViews | Where-Object { ($ExcludedDatastores -eq "" -or $_.Name -notmatch $ExcludedDatastores) } | Select-Object Name, @{N="NumVM";E={($_.vm).Count}} | Where-Object { $_.NumVM -gt $NumVMsPerDatastore} | Sort-Object NumVM -Descending
 
 $Header = "Number of VMs per Datastore over $($NumVMsPerDatastore) : [count]"
 

--- a/Plugins/40 Datastore/39 Datastore OverAllocation.ps1
+++ b/Plugins/40 Datastore/39 Datastore OverAllocation.ps1
@@ -16,7 +16,7 @@ $ExcludedDatastores = ""
 $OverAllocation = Get-vCheckSetting $Title "OverAllocation" $OverAllocation
 $ExcludedDatastores = Get-vCheckSetting $Title "ExcludedDatastores" $ExcludedDatastores
 
-$filteredstorageviews = $storageviews | Where-Object { $_.Name -notmatch $ExcludedDatastores }
+$filteredstorageviews = $storageviews | Where-Object { ($ExcludedDatastores -eq "" -or $_.Name -notmatch $ExcludedDatastores) }
 
 foreach ($storage in $filteredstorageviews)
 {

--- a/Plugins/40 Datastore/59 Datastores with Storage IO Control Disabled.ps1
+++ b/Plugins/40 Datastore/59 Datastores with Storage IO Control Disabled.ps1
@@ -13,7 +13,7 @@ $DatastoreIgnore = "local"
 # Update settings where there is an override
 $DatastoreIgnore = Get-vCheckSetting $Title "DatastoreIgnore" $DatastoreIgnore
 
-$Datastores | Where-Object {$_.Name -notmatch $DatastoreIgnore -and -not $_.StorageIOControlEnabled} | `
+$Datastores | Where-Object {($DatastoreIgnore -eq "" -or $_.Name -notmatch $DatastoreIgnore) -and -not $_.StorageIOControlEnabled} | `
    Sort-Object -Property Name | `
    Select-Object -Property Name,StorageIOControlEnabled
 

--- a/Plugins/60 VM/02 Snapshot Information.ps1
+++ b/Plugins/60 VM/02 Snapshot Information.ps1
@@ -10,7 +10,7 @@ $ExcludeCreator = "^(ExcludeMe|ExcludeMeToo)$"
 Add-Type -AssemblyName System.Web
 $Output = @()
 
-foreach ($Snapshot in ($VM | Get-Snapshot | Where-Object { $_.Created -lt (Get-Date).AddDays(- $SnapshotAge) -and $_.Name -notmatch $ExcludeName })) {
+foreach ($Snapshot in ($VM | Get-Snapshot | Where-Object { $_.Created -lt (Get-Date).AddDays(- $SnapshotAge) -and ($ExcludeName -eq "" -or $_.Name -notmatch $ExcludeName) })) {
 
     # This little +/-1 minute time span is a small buffer in case of time differences between the vCenter and the reporting server. This might cause wrong
     # results in the uncommon case of two different people creating a snapshot for the same VM within two minutes. In this scenario the wrong creator will be
@@ -20,7 +20,7 @@ foreach ($Snapshot in ($VM | Get-Snapshot | Where-Object { $_.Created -lt (Get-D
 
     if ($SnapshotEvent -eq $null) {
         $SnapshotCreator = "Unknown"
-    } elseif ($SnapshotEvent.UserName -match $ExcludeCreator) {
+    } elseif (($ExcludeCreator -ne "" -and $SnapshotEvent.UserName -match $ExcludeCreator)) {
         # This is the earliest point where I can neglect snapshots from certain creators
         continue
     } else {

--- a/Plugins/60 VM/100 VMs with CPU or Memory Reservations.ps1
+++ b/Plugins/60 VM/100 VMs with CPU or Memory Reservations.ps1
@@ -14,7 +14,7 @@ $MCRDoNotInclude = ""
 # Update settings where there is an override
 $MCRDoNotInclude = Get-vCheckSetting $Title "MCRDoNotInclude" $MCRDoNotInclude
 
-$FullVM | Where-Object {$_.Name -notmatch $MCRDoNotInclude -and ($_.config.cpuallocation.Reservation -ne "0" -or $_.config.memoryallocation.Reservation -ne "0")} | Select-Object Name, @{Name="CPUReservationMhz";E={$_.config.cpuallocation.Reservation}}, @{Name="MemReservationMB";E={$_.config.memoryallocation.Reservation}}
+$FullVM | Where-Object {($MCRDoNotInclude -eq "" -or $_.Name -notmatch $MCRDoNotInclude) -and ($_.config.cpuallocation.Reservation -ne "0" -or $_.config.memoryallocation.Reservation -ne "0")} | Select-Object Name, @{Name="CPUReservationMhz";E={$_.config.cpuallocation.Reservation}}, @{Name="MemReservationMB";E={$_.config.memoryallocation.Reservation}}
 
 # Change Log
 ## 1.0 : Initial Release

--- a/Plugins/60 VM/114 VM Tools Not Up to Date.ps1
+++ b/Plugins/60 VM/114 VM Tools Not Up to Date.ps1
@@ -16,7 +16,7 @@ $VMTMaxReturn = 30
 $VMTDoNotInclude = Get-vCheckSetting $Title "VMTDoNotInclude" $VMTDoNotInclude
 $VMTMaxReturn = Get-vCheckSetting $Title "VMTMaxReturn" $VMTMaxReturn
 
-$FullVM | Where-Object {$_.Name -notmatch $VMTDoNotInclude -and ($_.Runtime.Powerstate -eq "poweredOn" -And $_.Guest.toolsStatus -eq "toolsOld")} | `
+$FullVM | Where-Object {($VMTDoNotInclude -eq "" -or $_.Name -notmatch $VMTDoNotInclude) -and ($_.Runtime.Powerstate -eq "poweredOn" -And $_.Guest.toolsStatus -eq "toolsOld")} | `
    Select-Object Name, @{N="Version";E={$_.Guest.ToolsVersion}}, @{N="Status";E={$_.Guest.ToolsStatus}} | Sort-Object Name | Select-Object -First $VMTMaxReturn
 
 $Comments = ("The following VMs are running an older version of Tools than is available on its Host (Max Shown: {0} Exceptions: {1})" -f $VMTMaxReturn, $VMTDoNotInclude)

--- a/Plugins/60 VM/122 NonPersistent Disks.ps1
+++ b/Plugins/60 VM/122 NonPersistent Disks.ps1
@@ -16,7 +16,7 @@ $NPExcludeVM = Get-vCheckSetting $Title "NPExcludeVM" $NPExcludeVM
 
 # NonPersistent Disks
 $diskModes = [VMware.Vim.VirtualDiskMode]::independent_nonpersistent,[VMware.Vim.VirtualDiskMode]::nonpersistent
-ForEach($npvm in $FullVM | Where-Object {$_.Name -notmatch $NPExcludeVM}){
+ForEach($npvm in $FullVM | Where-Object {$NPExcludeVM -eq "" -or $_.Name -notmatch $NPExcludeVM}){
    $npvm.Config.Hardware.Device |
    Where-Object {$_ -is [VMware.Vim.VirtualDisk] -and $diskModes -contains $_.Backing.DiskMode} |
    Select-Object @{N="VM";E={$npvm.Name}},

--- a/Plugins/60 VM/22 Checking VM Hardware Version.ps1
+++ b/Plugins/60 VM/22 Checking VM Hardware Version.ps1
@@ -17,7 +17,7 @@ $vmIgnore = "vShield*|dsva*"
 $HWVers = Get-vCheckSetting $Title "HWVers" $HWVers
 $vmIgnore = Get-vCheckSetting $Title "vmIgnore" $vmIgnore
 
-$VM | Where-Object {$_.Name -notmatch $vmIgnore -and [INT]($_.HWVersion)-lt $HWVers} | Select-Object Name, HWVersion
+$VM | Where-Object {($vmIgnore -eq "" -or $_.Name -notmatch $vmIgnore) -and [INT]($_.HWVersion)-lt $HWVers} | Select-Object Name, HWVersion
 
 # Change Log
 ## 1.3 : Added Get-vCheckSetting

--- a/Plugins/60 VM/25 VMs in inconsistent folders.ps1
+++ b/Plugins/60 VM/25 VMs in inconsistent folders.ps1
@@ -16,7 +16,7 @@ $DatastoreIgnore = Get-vCheckSetting $Title "DatastoreIgnore" $DatastoreIgnore
 Foreach ($CHKVM in $FullVM){
    $Folder = ((($CHKVM.Summary.Config.VmPathName).Split(']')[1]).Split('/'))[0].TrimStart(' ')
    $Path = ($CHKVM.Summary.Config.VmPathName).Split('/')[0]
-   If (($CHKVM.Name-ne $Folder) -and ($Path -notmatch $DatastoreIgnore)){
+   If (($CHKVM.Name-ne $Folder) -and ($DatastoreIgnore -eq "" -or $Path -notmatch $DatastoreIgnore)){
       New-Object -TypeName PSObject -Property @{
          "VM" = $CHKVM.Name
          "Path" = $Path }

--- a/Plugins/60 VM/26 No VM Tools.ps1
+++ b/Plugins/60 VM/26 No VM Tools.ps1
@@ -14,7 +14,7 @@ $VMTDoNotInclude = ""
 # Update settings where there is an override
 $VMTDoNotInclude = Get-vCheckSetting $Title "VMTDoNotInclude" $VMTDoNotInclude
 
-$FullVM | Where-Object {$_.Name -notmatch $VMTDoNotInclude -and $_.Runtime.Powerstate -eq "poweredOn" -And ($_.Guest.toolsStatus -eq "toolsNotInstalled" -Or $_.Guest.ToolsStatus -eq "toolsNotRunning")} | Select-Object Name, @{N="Status";E={$_.Guest.ToolsStatus}}
+$FullVM | Where-Object {($VMTDoNotInclude -eq "" -or $_.Name -notmatch $VMTDoNotInclude) -and $_.Runtime.Powerstate -eq "poweredOn" -And ($_.Guest.toolsStatus -eq "toolsNotInstalled" -Or $_.Guest.ToolsStatus -eq "toolsNotRunning")} | Select-Object Name, @{N="Status";E={$_.Guest.ToolsStatus}}
 
 # Change Log
 ## 1.2 : Added Get-vCheckSetting

--- a/Plugins/60 VM/27 VM Tools Issues.ps1
+++ b/Plugins/60 VM/27 VM Tools Issues.ps1
@@ -14,7 +14,7 @@ $VMTDoNotInclude = ""
 # Update settings where there is an override
 $VMTDoNotInclude = Get-vCheckSetting $Title "VMTDoNotInclude" $VMTDoNotInclude
 
-$FullVM | Where-Object {$_.Name -notmatch $VMTDoNotInclude -and $_.Guest.GuestState -eq "Running" -And ($_.Guest.GuestFullName -eq $NULL -or $_.Guest.IPAddress -eq $NULL -or $_.Guest.HostName -eq $NULL -or $_.Guest.Disk -eq $NULL -or $_.Guest.Net -eq $NULL)} | Select-Object Name, @{N="IPAddress";E={$_.Guest.IPAddress[0]}},@{n="OSFullName";E={$_.Guest.GuestFullName}},@{n="HostName";e={$_.guest.hostname}},@{N="NetworkLabel";E={$_.guest.Net[0].Network}} -ErrorAction SilentlyContinue | Sort-Object Name
+$FullVM | Where-Object {($VMTDoNotInclude -eq "" -or $_.Name -notmatch $VMTDoNotInclude) -and $_.Guest.GuestState -eq "Running" -And ($_.Guest.GuestFullName -eq $NULL -or $_.Guest.IPAddress -eq $NULL -or $_.Guest.HostName -eq $NULL -or $_.Guest.Disk -eq $NULL -or $_.Guest.Net -eq $NULL)} | Select-Object Name, @{N="IPAddress";E={$_.Guest.IPAddress[0]}},@{n="OSFullName";E={$_.Guest.GuestFullName}},@{n="HostName";e={$_.guest.hostname}},@{N="NetworkLabel";E={$_.guest.Net[0].Network}} -ErrorAction SilentlyContinue | Sort-Object Name
 
 # Change Log
 ## 1.2 : Added Get-vCheckSetting

--- a/Plugins/60 VM/28 Removable Media Connected.ps1
+++ b/Plugins/60 VM/28 Removable Media Connected.ps1
@@ -14,7 +14,7 @@ $IgnoreVMMedia = ""
 # Update settings where there is an override
 $IgnoreVMMedia = Get-vCheckSetting $Title "IgnoreVMMedia" $IgnoreVMMedia
 
-$FullVM | Where-Object {$_.runtime.powerState -eq "PoweredOn" -And $_.Name -notmatch $IgnoreVMMedia} | 
+$FullVM | Where-Object {$_.runtime.powerState -eq "PoweredOn" -And ($IgnoreVMMedia -eq "" -or $_.Name -notmatch $IgnoreVMMedia)} | 
    % { $VMName = $_.Name; $_.config.hardware.device | Where-Object {($_ -is [VMware.Vim.VirtualFloppy] -or $_ -is [VMware.Vim.VirtualCdrom]) -and $_.Connectable.Connected} | 
       Select-Object @{Name="VMName"; Expression={ $VMName}}, 
              @{Name="Device Type"; Expression={ $_.GetType().Name}},

--- a/Plugins/60 VM/30 Single Storage VMs.ps1
+++ b/Plugins/60 VM/30 Single Storage VMs.ps1
@@ -17,9 +17,9 @@ $LDSDoNotInclude = "Local|datastore1"
 $LVMDoNotInclude = Get-vCheckSetting $Title "LVMDoNotInclude" $LVMDoNotInclude
 $LDSDoNotInclude = Get-vCheckSetting $Title "LDSDoNotInclude" $LDSDoNotInclude
 
-$unSharedDatastore = $storageviews | Where-Object {$_.Name -notmatch $LDSDoNotInclude -and -not $_.summary.multiplehostaccess} | Select-Object -Expand Name
+$unSharedDatastore = $storageviews | Where-Object {($LDSDoNotInclude -eq "" -or $_.Name -notmatch $LDSDoNotInclude) -and -not $_.summary.multiplehostaccess} | Select-Object -Expand Name
 
-$FullVM | Where-Object {$_.Name -notmatch $LVMDoNotInclude} | Where-Object {$_.Runtime.ConnectionState -notmatch "invalid|orphaned"} | Foreach-Object {$_.layoutex.file} | Where-Object {$_.type -ne "log" -and $_.name -notmatch ".vswp$" -And $unSharedDatastore -contains $_.name.Split(']')[0].Split('[')[1]} | Select-Object Name
+$FullVM | Where-Object {($LVMDoNotInclude -eq "" -or $_.Name -notmatch $LVMDoNotInclude)} | Where-Object {$_.Runtime.ConnectionState -notmatch "invalid|orphaned"} | Foreach-Object {$_.layoutex.file} | Where-Object {$_.type -ne "log" -and $_.name -notmatch ".vswp$" -And $unSharedDatastore -contains $_.name.Split(']')[0].Split('[')[1]} | Select-Object Name
 
 # Change Log
 ## 1.4 : Added Get-vCheckSetting

--- a/Plugins/60 VM/48 Find VM Disk Format.ps1
+++ b/Plugins/60 VM/48 Find VM Disk Format.ps1
@@ -9,7 +9,7 @@ $DatastoreIgnore = "local"
 $diskformat = Get-vCheckSetting $Title "diskformat" $diskformat
 $DatastoreIgnore = Get-vCheckSetting $Title "DatastoreIgnore" $DatastoreIgnore
 
-$VM | Get-HardDisk | Where-Object {($_.storageformat -match $diskformat) -and ($_.Filename -notmatch $DatastoreIgnore)} | Select-Object @{N="VM";E={$_.parent.name}}, @{N="DiskName";E={$_.name}}, @{N="Format";E={$_.storageformat}}, @{N="FileName";E={$_.filename}}
+$VM | Get-HardDisk | Where-Object {($_.storageformat -match $diskformat) -and ($DatastoreIgnore -eq "" -or $_.Filename -notmatch $DatastoreIgnore)} | Select-Object @{N="VM";E={$_.parent.name}}, @{N="DiskName";E={$_.name}}, @{N="Format";E={$_.storageformat}}, @{N="FileName";E={$_.filename}}
 
 $Title = "Find VMs with thick or thin provisioned vmdk"
 $Header = "VMs with $diskformat provisioned vmdk(s): [count]"

--- a/Plugins/60 VM/54 Virtual Machines with incorrect OS Configuration.ps1
+++ b/Plugins/60 VM/54 Virtual Machines with incorrect OS Configuration.ps1
@@ -14,7 +14,7 @@ $VMTDoNotInclude = "VM1_*|VM2_*"
 # Update settings where there is an override
 $VMTDoNotInclude = Get-vCheckSetting $Title "VMTDoNotInclude" $VMTDoNotInclude
 
-$FullVM | Where-Object {$_.Name -notmatch $VMTDoNotInclude} |`
+$FullVM | Where-Object {($VMTDoNotInclude -eq "" -or $_.Name -notmatch $VMTDoNotInclude)} |`
    Where-Object {$_.Guest.GuestId -and $_.Guest.GuestId -ne $_.Config.GuestId} | `
    Select-Object -Property Name,@{N="GuestId";E={$_.Guest.GuestId}},
       @{N="Installed Guest OS";E={$_.Guest.GuestFullName}},

--- a/Plugins/60 VM/58 Virtual machines with less hard disks than partitions.ps1
+++ b/Plugins/60 VM/58 Virtual machines with less hard disks than partitions.ps1
@@ -14,7 +14,7 @@ $VMTDoNotInclude = "VM1_*|VM2_*"
 # Update settings where there is an override
 $VMTDoNotInclude = Get-vCheckSetting $Title "VMTDoNotInclude" $VMTDoNotInclude
 
-$FullVM | Where-Object {$_.Name -notmatch $VMTDoNotInclude} |
+$FullVM | Where-Object {($VMTDoNotInclude -eq "" -or $_.Name -notmatch $VMTDoNotInclude)} |
    Where-Object {$_.Config.ManagedBy.ExtensionKey -ne 'com.vmware.vcDr'} |
    Select-Object -Property Name,@{N="NrOfHardDisks";E={($_.Layout.Disk|measure).count}},@{N="NrOfGuestDisks";E={($_.Guest.Disk|measure).count}},@{N="GuestFamily";E={$_.Guest.GuestFamily}} |
    Where-Object {$_.GuestFamily -eq "windowsGuest" -and $_.NrOfHardDisks -lt $_.NrOfGuestDisks}

--- a/Plugins/60 VM/60 Powered Off VMs.ps1
+++ b/Plugins/60 VM/60 Powered Off VMs.ps1
@@ -24,9 +24,9 @@ $PoweredOffDays = Get-vCheckSetting $Title "PoweredOffDays" $PoweredOffDays
 $VM | Where-Object {$_.ExtensionData.Config.ManagedBy.ExtensionKey -ne 'com.vmware.vcDr' -and 
                 $_.PowerState -eq "PoweredOff" -and 
                 $_.LastPoweredOffDate -lt $date.AddDays(-$PoweredOffDays) -and
-                $_.Name -notmatch $IgnoredVMs -and 
-                $_.Folder.Name -notmatch $IgnoredVMFolder -and
-                $_.ExtensionData.Config.Files.VmPathName -notmatch $IgnoredVMpath} |
+                ($IgnoredVMs -eq "" -or $_.Name -notmatch $IgnoredVMs) -and 
+                ($IgnoredVMFolder -eq "" -or $_.Folder.Name -notmatch $IgnoredVMFolder) -and
+                ($IgnoredVMpath -eq "" -or $_.ExtensionData.Config.Files.VmPathName -notmatch $IgnoredVMpath)} |
   Select-Object -Property Name, LastPoweredOffDate, @{l = 'Folder'; e = {$_.Folder.Name}}, Notes |
   Sort-Object -Property LastPoweredOffDate
 

--- a/Plugins/60 VM/66 Misnamed VM.ps1
+++ b/Plugins/60 VM/66 Misnamed VM.ps1
@@ -14,7 +14,7 @@ $MNDoNotInclude = "VM1_*|VM2_*"
 # Update settings where there is an override
 $MNDoNotInclude = Get-vCheckSetting $Title "MNDoNotInclude" $MNDoNotInclude
 
-($FullVM | Where-Object {$_.Runtime.PowerState -eq 'poweredOn' -AND $_.Name -notmatch $MNDoNotInclude -AND $_.Guest.HostName -ne "" -AND $_.Guest.HostName -notmatch $_.Name }) |
+($FullVM | Where-Object {$_.Runtime.PowerState -eq 'poweredOn' -AND ($MNDoNotInclude -eq "" -or $_.Name -notmatch $MNDoNotInclude) -AND $_.Guest.HostName -ne "" -AND $_.Guest.HostName -notmatch $_.Name }) |
    Foreach-Object {
       $vmguest = $_
       if ($vmguest.Parent -ne $null)

--- a/Plugins/60 VM/85 Snapshot Activity.ps1
+++ b/Plugins/60 VM/85 Snapshot Activity.ps1
@@ -16,7 +16,7 @@ $snapshotUserException = "s-veeam"
 $VMsNewRemovedAge = Get-vCheckSetting $Title "VMsNewRemovedAge" $VMsNewRemovedAge
 $snapshotUserException = Get-vCheckSetting $Title "snapshotUserException" $snapshotUserException
 
-Get-VIEventPlus -Start ((get-date).adddays(- $VMsNewRemovedAge)) -EventType "TaskEvent" | ? { $_.FullFormattedMessage -match "snapshot" -and $_.userName -notmatch $snapshotUserException } | Select-Object @{ N = "Created Time"; E = { ($_.createdTime).ToLocalTime() } }, @{ N = "User"; E = { $_.userName } }, @{ N = "VM Name"; E = { $_.vm.name } }, @{ N = "Description"; E = { $_.FullFormattedMessage } } | Sort-Object "VM Name", "Created Time"
+Get-VIEventPlus -Start ((get-date).adddays(- $VMsNewRemovedAge)) -EventType "TaskEvent" | ? { $_.FullFormattedMessage -match "snapshot" -and ($snapshotUserException -eq "" -or $_.userName -notmatch $snapshotUserException) } | Select-Object @{ N = "Created Time"; E = { ($_.createdTime).ToLocalTime() } }, @{ N = "User"; E = { $_.userName } }, @{ N = "VM Name"; E = { $_.vm.name } }, @{ N = "Description"; E = { $_.FullFormattedMessage } } | Sort-Object "VM Name", "Created Time"
 
 $Comments = ("Last {0} Day(s) with user exception {1}" -f $VMsNewRemovedAge, $snapshotUserException)
 


### PR DESCRIPTION
$Ignore = ""; ("string" -notmatch $Ignore);  returns $false
instead
$Ignore = ""; ($Ignore -eq "" -or "string" -notmatch $Ignore);

Fix for issue #682