### PR TITLE
feat: Added cluster overcommitment rate

### DIFF
--- a/Plugins/20 Cluster/40 Cluster Overcommitment Rate.ps1
+++ b/Plugins/20 Cluster/40 Cluster Overcommitment Rate.ps1
@@ -9,8 +9,6 @@ $PluginVersion = "1.0"
 $PluginCategory = "vSphere"
 $Display = "Table"
 
-$result = @()
-
 foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort-Object Name)) {
     $cluvmlist = $VM | Where-Object { $cluv.Host -contains $_.VMHost.Id  }
 
@@ -28,7 +26,5 @@ foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort
     $clusterInfo.CommittedMem = $committedMem
     $clusterInfo.OverCommitmentRateCpu = [math]::Round($committedCpu / $totalCpu * 100, 2)
     $clusterInfo.OverCommitmentRateMem = [math]::Round($committedMem / $totalMem * 100, 2)
-    $result += $clusterInfo
+    $clusterInfo
 }
-
-$result

--- a/Plugins/20 Cluster/40 Cluster Overcommitment Rate.ps1
+++ b/Plugins/20 Cluster/40 Cluster Overcommitment Rate.ps1
@@ -1,0 +1,34 @@
+﻿# Start of Settings   
+# End of Settings
+
+$Title = "Cluster Overcommitment rate"
+$Header = "Cluster Overcommitment rate"
+$Comments = "The ratio of the VM-assigned CPU and memory to the actual existing hardware CPU amd memory"
+$Author = "Dennis Ploeger"
+$PluginVersion = "1.0"
+$PluginCategory = "vSphere"
+$Display = "Table"
+
+$result = @()
+
+foreach ($cluv in ($clusviews | Where-Object {$_.Summary.NumHosts -gt 0 } | Sort-Object Name)) {
+    $cluvmlist = $VM | Where-Object { $cluv.Host -contains $_.VMHost.Id  }
+
+    $totalCpu = $cluv.Summary.NumCpuThreads
+    $totalMem = $cluv.Summary.EffectiveMemory/1024
+
+    $committedCpu = ($cluvmlist|Measure-Object -Sum -Property NumCpu).sum
+    $committedMem = ($cluvmlist|Measure-Object -Sum -Property MemoryGB).sum
+
+    $clusterInfo = "" | Select-Object Name, TotalCPU, TotalMem, CommittedCPU, CommittedMem, OverCommitmentRateCpu, OverCommitmentRateMem
+    $clusterInfo.Name = $cluv.Name
+    $clusterInfo.TotalCPU = $totalCpu
+    $clusterInfo.TotalMem = [math]::Round($totalMem, 2)
+    $clusterInfo.CommittedCPU = $committedCpu
+    $clusterInfo.CommittedMem = $committedMem
+    $clusterInfo.OverCommitmentRateCpu = [math]::Round($committedCpu / $totalCpu * 100, 2)
+    $clusterInfo.OverCommitmentRateMem = [math]::Round($committedMem / $totalMem * 100, 2)
+    $result += $clusterInfo
+}
+
+$result


### PR DESCRIPTION
This plugin calculates the rate between the actual existing CPUs and memory to the committed CPUs and memory in the virtual hardware of every VM.