### PR TITLE
fixes setting up credentials and logic of initial setup

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -9,7 +9,6 @@ $PluginCategory = "vSphere"
 # Start of Settings
 # Please Specify the address (and optional port) of the vCenter server to connect to [servername(:port)]
 $Server = "192.168.0.0"
-
 # Include SRM placeholder VMs in report?
 $IncludeSRMPlaceholders = $false
 # End of Settings
@@ -115,8 +114,8 @@ switch ($platform.OSFamily) {
         Get-Module -ListAvailable PowerCLI* | Import-Module
     }
     "Linux" { 
-        $Outputpath = $templocation
         $templocation = "/tmp"
+        $Outputpath = $templocation
         Get-Module -ListAvailable PowerCLI* | Import-Module
     }
     "Windows" { 
@@ -149,22 +148,15 @@ switch ($platform.OSFamily) {
 
 $OpenConnection = $global:DefaultVIServers | Where-Object { $_.Name -eq $VIServer }
 if($OpenConnection.IsConnected) {
-   Write-CustomOut ( "{0}: {1}" -f $pLang.connReuse, $Server )
-   $VIConnection = $OpenConnection
+    Write-CustomOut ( "{0}: {1}" -f $pLang.connReuse, $Server )
+    $VIConnection = $OpenConnection
 } else {
-  If (Test-Path $vCentercredfile) {
-    $LoadedCredentials = Import-Clixml $vCentercredfile
-    $vCentercreds = New-Object System.Management.Automation.PsCredential($LoadedCredentials.Username,($LoadedCredentials.Password | ConvertTo-SecureString))
-  } Else {
-    Write-Host "Please enter credentials to connect to vCenter, these will be stored in an encrypted file: $vCentercredfile" 
-       $vCentercreds = Get-Credential
-       $Pass = $vCentercreds.Password | ConvertFrom-SecureString
-       $Username = $vCentercreds.UserName
-       $Store = "" | Select-Object Username, Password
-       $Store.Username = $Username
-       $Store.Password = $Pass
-       $Store | Export-Clixml $vCentercredfile
-  }
+    If (Test-Path $vCentercredfile) {
+        $LoadedCredentials = Get-vCenterCredentials($vCentercredfile)
+    } Else {
+        $LoadedCredentials = Set-vCenterCredentials($vCentercredfile)
+    }
+    $vCentercreds = New-Object System.Management.Automation.PsCredential($LoadedCredentials.Username, $LoadedCredentials.Password)
     Write-CustomOut ( "{0}: {1}" -f $pLang.connOpen, $Server )
     $VIConnection = Connect-VIServer -Server $VIServer -Port $Port -Credential $vCentercreds
 }
@@ -466,10 +458,10 @@ PS> Get-Datastore | Get-HttpDatastoreItem -Credential $cred -Recurse
     [cmdletbinding()]
     param(
         [VMware.VimAutomation.ViCore.Types.V1.VIServer]$Server = $global:DefaultVIServer,
-        [parameter(Mandatory=$true,ValueFromPipelineByPropertyName,ParameterSetName=Datastore)]
+        [parameter(Mandatory=$true,ValueFromPipelineByPropertyName,ParameterSetName='Datastore')]
         [Alias('Name')]
         [string]$Datastore,
-        [parameter(Mandatory=$true,ParameterSetName=Path)]
+        [parameter(Mandatory=$true,ParameterSetName='Path')]
         [string]$Path = '',
         [PSCredential]$Credential,
         [Switch]$Recurse = $false,

--- a/Plugins/30 Host/126 Host Linkfailures and CRC errors.ps1
+++ b/Plugins/30 Host/126 Host Linkfailures and CRC errors.ps1
@@ -1,4 +1,4 @@
-﻿$Title = "Check Fibre Channel Link failures and CRC errors on HBA cards"
+$Title = "Check Fibre Channel Link failures and CRC errors on HBA cards"
 $Comments = "Fibre Channel Link failures and CRC errors can effect storage performance in a FC SAN environment"
 $Display = "Table"
 $Author = "Wim Baars"

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -186,7 +186,7 @@ Function Invoke-Settings {
 				$Var = $Split[0]
 				$CurSet = $Split[1].Trim()
 				
-				# Check if the current setting is in speech marks
+				# Check if the current setting is quoted
 				$String = $false
 				if ($CurSet -match '"') {					
 					$String = $true
@@ -754,8 +754,8 @@ These credentials will be stored securely at '$OutputFile'."
     $export.Username = $NewCredential.Username 
     $export.EncryptedPassword = $NewCredential.Password | ConvertFrom-SecureString 
     $export | Export-Clixml $OutputFile
-    Write-Host -foregroundcolor green "Credentials saved to: " -noNewLine 
-    Get-Item $OutputFile
+    Write-Host -foregroundcolor green "Credentials saved to: $OutputFile"
+    Return $NewCredential
 }
 
 <# Retrieves the securely stored vCenter credentials from a file on disk. #>
@@ -839,14 +839,6 @@ $SetupSetting = Invoke-Expression (($file[$SetupLine]).Split("="))[1]
 ## Include GlobalVariables and validate settings (at the moment just check they exist)
 . $GlobalVariables
 
-if ($SetupSetting -or $config) {
-    Set-vCenterCredentials($vCenterCredentialsFile)
-        
-    Write-Warning -Message "Configuration is complete. You can now re-run vCheck to use the stored configuration."
-
-    Exit 0;
-}
-
 $vcvars = @("SetupWizard", "reportHeader", "SMTPSRV", "EmailFrom", "EmailTo", "EmailSubject", "DisplaytoScreen", "SendEmail", "SendAttachment", "TimeToRun", "PluginSeconds", "Style", "Date")
 foreach ($vcvar in $vcvars) {
 	if (!($(Get-Variable -Name "$vcvar" -Erroraction 'SilentlyContinue'))) {
@@ -908,7 +900,7 @@ if ($SetupSetting -or $config -or $GUIConfig) {
 			Write-Warning -Message "$($_.value)"
 		}
 
-	} elseif ($config) {
+	} elseif ($SetupSetting -or $config) {
 		Invoke-Settings -Filename $GlobalVariables -GB $true
 		Foreach ($plugin in $vCheckPlugins) {
 			Invoke-Settings -Filename $plugin.Fullname


### PR DESCRIPTION
This fixes setting up a credential file. If file does not exist, user will be asked for credentials and credential file will be created.
If a credential exists, credentials from file will be used.

Also the initial config is working again. This got broken with previous commits.