### PR TITLE
Update 48 Find VM Disk Format.ps1 - Filter Disktype

### DIFF
--- a/Plugins/60 VM/48 Find VM Disk Format.ps1
+++ b/Plugins/60 VM/48 Find VM Disk Format.ps1
@@ -9,7 +9,7 @@ $DatastoreIgnore = "local"
 $diskformat = Get-vCheckSetting $Title "diskformat" $diskformat
 $DatastoreIgnore = Get-vCheckSetting $Title "DatastoreIgnore" $DatastoreIgnore
 
-$VM | Get-HardDisk | Where-Object {($_.storageformat -match $diskformat) -and ($_.Filename -notmatch $DatastoreIgnore)} | Select-Object @{N="VM";E={$_.parent.name}}, @{N="DiskName";E={$_.name}}, @{N="Format";E={$_.storageformat}}, @{N="FileName";E={$_.filename}}
+$VM | Get-HardDisk -DiskType Flat | Where-Object {($_.storageformat -match $diskformat) -and ($_.Filename -notmatch $DatastoreIgnore)} | Select-Object @{N="VM";E={$_.parent.name}}, @{N="DiskName";E={$_.name}}, @{N="Format";E={$_.storageformat}}, @{N="FileName";E={$_.filename}}
 
 $Title = "Find VMs with thick or thin provisioned vmdk"
 $Header = "VMs with $diskformat provisioned vmdk(s): [count]"


### PR DESCRIPTION
Adding '-DiskType Flat' to Get-Harddisk will improve performance as the data will be filtered in vCenter before being returned to the cmdlet.  As a minor bonus, it will also reduce output noise to the screen.  An error is generated for any non-flat disks because they don't have the StorageFormat property.