### PR TITLE
Update 62 Unwanted Virtual Hardware.ps1 - Filter VM name

### DIFF
--- a/Plugins/60 VM/62 Unwanted Virtual Hardware.ps1
+++ b/Plugins/60 VM/62 Unwanted Virtual Hardware.ps1
@@ -9,12 +9,13 @@ $PluginCategory = "vSphere"
 # Start of Settings
 # Find unwanted virtual hardware
 $unwantedHardware = "VirtualUSBController|VirtualParallelPort|VirtualSerialPort"
+$ExcludeVM = "vm1|vm2"
 # End of Settings
 
 # Update settings where there is an override
 $unwantedHardware = Get-vCheckSetting $Title "unwantedHardware" $unwantedHardware
 
-foreach ($vmguest in $FullVM) {
+foreach ($vmguest in ($FullVM | Where-Object { $_.Name -notmatch $ExcludeVM })) {
    $vmguest.Config.Hardware.Device | Where-Object {$_.GetType().Name -match $unwantedHardware} | Foreach-Object {
       New-Object -TypeName PSObject -Property @{
          Name = $vmguest.name 


### PR DESCRIPTION
Added ' $ExcludeVM = "vm1|vm2" ' variable and added the filter with ' ($FullVM | Where-Object { $_.Name -notmatch $ExcludeVM }) '.