### PR TITLE
Update script so it will not overwrite variable $VM

### DIFF
--- a/Plugins/60 VM/121 BusSharingMode - Physical and Virtual.ps1
+++ b/Plugins/60 VM/121 BusSharingMode - Physical and Virtual.ps1
@@ -10,10 +10,10 @@ $PluginCategory = "vSphere"
 # End of Settings
 
 # BusSharingMode - Physical and Virtual
-ForEach ($vm in $FullVM){
-    $scsi = $vm.Config.Hardware.Device | Where-Object {$_ -is [VMware.Vim.VirtualSCSIController] -and ($_.SharedBus -eq "physicalSharing" -or $_.SharedBus -eq "virtualSharing")}
+ForEach ($myvm in $FullVM){
+    $scsi = $myvm.Config.Hardware.Device | Where-Object {$_ -is [VMware.Vim.VirtualSCSIController] -and ($_.SharedBus -eq "physicalSharing" -or $_.SharedBus -eq "virtualSharing")}
     if ($scsi){
-        $scsi | Select-Object @{N="VM";E={$vm.Name}},
+        $scsi | Select-Object @{N="VM";E={$myvm.Name}},
             @{N="Controller";E={$_.DeviceInfo.Label}},
             @{N="BusSharingMode";E={$_.SharedBus}}
     }


### PR DESCRIPTION
I have tested and when this script is run, the variable $VM (which contains alls VMs) is overwritten by the last VM checked.
I have checked the number of objects in variable $VM and when this script is run, the count is 1 (the last one) causing next scripts to fail (as I only have 1 VM).