### PR TITLE
Fix Missing ESX patches plugin out of date and broken #623

### DIFF
--- a/Plugins/30 Host/46 Missing ESX patches.ps1
+++ b/Plugins/30 Host/46 Missing ESX patches.ps1
@@ -3,17 +3,17 @@ $Header = "Missing ESX(i) updates and patches: [count]"
 $Comments = "The following updates and/or patches are not applied."
 $Display = "Table"
 $Author = "Luc Dekens"
-$PluginVersion = 1.1
+$PluginVersion = 1.2
 $PluginCategory = "vSphere"
 
-# Start of Settings 
-# End of Settings 
+# Start of Settings
+# End of Settings
 
 # Note: This plugin needs the vCenter Update Manager PowerCLI snap-in installed
 # https://communities.vmware.com/community/vmtn/automationtools/powercli/updatemanager
 # (Current version 5.1 locks up in PowerShell v3; use "-version 2" when launching.)
 
-If (Get-PSSnapin Vmware.VumAutomation -ErrorAction SilentlyContinue) {
+If (Get-Module -ListAvailable Vmware.VumAutomation -ErrorAction SilentlyContinue) {
    foreach($esx in $VMH){
       foreach($baseline in (Get-Compliance -Entity $esx -Detailed | Where-Object {$_.Status -eq "NotCompliant"})){
          $baseline.NotCompliantPatches |
@@ -23,3 +23,7 @@ If (Get-PSSnapin Vmware.VumAutomation -ErrorAction SilentlyContinue) {
       }
    }
 }
+
+# Changelog
+## 1.2 : Replaced Get-PSSnapin with (Get-Module -ListAvailable Vmware.VumAutomation)
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 - Fix Missing ESX patches plugin out of date and broken issue

## Motivation and Context

- Re-enable the ability to obtain missing patches from Esxi

## How Has This Been Tested?
 
- Tested in my homelab

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1002783/198858005-4e4c34d8-23d6-432b-9992-5fba533c6bc7.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
