### PR TITLE
Issue Fix 695 and 705

### DIFF
--- a/Plugins/00 Initialize/01 General Information.ps1
+++ b/Plugins/00 Initialize/01 General Information.ps1
@@ -3,7 +3,7 @@ $Header =  "General Information"
 $Comments = "General details on the infrastructure"
 $Display = "List"
 $Author = "Alan Renouf, Frederic Martin"
-$PluginVersion = 1.3
+$PluginVersion = 1.4
 $PluginCategory = "vSphere"
 
 # Start of Settings 
@@ -17,13 +17,18 @@ $SDRSMigrateAge = 1
 $DRSMigrateAge = Get-vCheckSetting $Title "DRSMigrateAge" $DRSMigrateAge
 $SDRSMigrateAge = Get-vCheckSetting $Title "SDRSMigrateAge" $SDRSMigrateAge
 
-if ($DRSMigrateAge -eq $SDRSMigrateAge -or $VIVersion -lt 5){
-    $MigrationQuery1 = Get-VIEventPlus -Start ($Date).AddDays(-$DRSMigrateAge) -Type Info
+if ($VIVersion -lt 5) {
+   $DRSMigrations = Get-VIEventPlus -Start $Date.AddDays(-$DRSMigrateAge) -EventType 'DrsVmMigratedEvent' | Select-Object CreatedTime, FullFormattedMessage
 }
-else 
-{
-   $MigrationQuery1 = Get-VIEventPlus -Start ($Date).AddDays(-$DRSMigrateAge) -Type Info
-   $MigrationQuery2 = Get-VIEventPlus -Start ($Date).AddDays(-$SDRSMigrateAge) -Type Info
+else {
+   $DRSMigrations = Get-VIEventPlus -Start $Date.AddDays(-$DRSMigrateAge) -EventType 'DrsVmMigratedEvent' | Select-Object CreatedTime, FullFormattedMessage
+   $StorageDRSQuery = Get-VIEventPlus -Start $Date.AddDays(-$SDRSMigrateAge) -EventType 'com.vmware.vc.sdrs.StorageDrsStoragePlacementEvent'
+   $SDRSMigrations = ForEach ($Event in $StorageDRSQuery) {
+      New-Object -TypeName PSObject -Property @{
+         'CreatedTime' = $Event.CreatedTime
+         'FullFormattedMessage' = "SDRS migrated $($Event.Arguments.Value[0]) to $($Event.Arguments.Value[2]) in datastore cluster $($Event.ObjectName)."
+      }
+   }
 }
 
 $Info = New-Object -TypeName PSObject -Property ([ordered]@{
@@ -38,14 +43,14 @@ $Info = New-Object -TypeName PSObject -Property ([ordered]@{
 
 # Don't display DRS line if 0 days are set
 if ($DRSMigrateAge -gt 0) {
-   $Info | Add-Member Noteproperty "DRS Migrations for last $($DRSMigrateAge) Days" (@($MigrationQuery1 | Where-Object {$_.GetType().Name -eq "DrsVmMigratedEvent"}).Count)
+   $Info | Add-Member Noteproperty "DRS Migrations for last $($DRSMigrateAge) Days" (@($DRSMigrations).Count)
 }
 
 # Adding vSphere 5 informations
 if ($VIVersion -ge 5) {
    $Info | Add-Member Noteproperty "Number of Datastore Clusters" $(@($DatastoreClustersView).Count)
-   if (($MigrationQuery2) -and ($SDRSMigrateAge -gt 0)) {
-      $Info | Add-Member Noteproperty "Storage DRS Migrations for last $($SDRSMigrateAge) Days" (@($MigrationQuery2 | Where-Object {$_.FullFormattedMessage -imatch "(Storage vMotion){1}.*(DRS){1}"}).Count)
+   if (($SDRSMigrations) -and ($SDRSMigrateAge -gt 0)) {
+      $Info | Add-Member Noteproperty "Storage DRS Migrations for last $($SDRSMigrateAge) Days" (@($SDRSMigrations).Count)
    }
 }
 
@@ -55,3 +60,4 @@ $Info
 ## 1.1 : Adding some vSphere5 features (Storage Pod, StorageDRS migration)
 ## 1.2 : Generalised the DRS Event Log Queries for use here and Plugin 17, potentially more efficient if $DRSMigrateAge and $SDRSMigrateAge are equal
 ## 1.3 : Add Get-vCheckSetting calls
+## 1.4 : Changed DRS and SDRS Event Log Queries to be more efficient. Issue #695

--- a/Plugins/10 vCenter/23 VI Events.ps1
+++ b/Plugins/10 vCenter/23 VI Events.ps1
@@ -2,7 +2,7 @@ $Title = "Checking VI Events"
 $Comments = "The following errors were logged in the vCenter Events tab, you may wish to investigate these"
 $Display = "Table"
 $Author = "Alan Renouf"
-$PluginVersion = 1.2
+$PluginVersion = 1.3
 $PluginCategory = "vSphere"
 
 # Start of Settings 
@@ -10,6 +10,9 @@ $PluginCategory = "vSphere"
 $VCEventAge = 1
 # End of Settings 
 
-Get-VIEventPlus -Start ($Date).AddDays(-$VCEventAge ) -EventType Error | Select-Object @{N="Host";E={$_.host.name}}, createdTime, @{N="User";E={($_.userName.split("\"))[1]}}, fullFormattedMessage
+Get-VIEventPlus -Start ($Date).AddDays(-$VCEventAge ) -EventCategory 'Error' | Select-Object @{N="Host";E={$_.host.name}}, createdTime, @{N="User";E={($_.userName.split("\"))[1]}}, fullFormattedMessage
 
 $Header = ("Error Events (Last {0} Day(s)): [count]" -f $VCEventAge)
+
+#Changelog
+## 1.3 Changed -EventType to -EventCategory with updated Get-VIEventPlus function. Issue #705

--- a/Plugins/20 Cluster/17 DRS Migrations.ps1
+++ b/Plugins/20 Cluster/17 DRS Migrations.ps1
@@ -2,7 +2,7 @@ $Title = "DRS & SDRS Migrations"
 $Comments = "Multiple DRS Migrations may be an indication of overloaded hosts, check resource levels of the cluster"
 $Display = "Table"
 $Author = "Alan Renouf, Jonathan Medd"
-$PluginVersion = 1.3
+$PluginVersion = 1.4
 $PluginCategory = "vSphere"
 
 # Start of Settings 
@@ -16,29 +16,21 @@ $SDRSMigrateAge = 1
 $DRSMigrateAge = Get-vCheckSetting $Title "DRSMigrateAge" $DRSMigrateAge
 $SDRSMigrateAge = Get-vCheckSetting $Title "SDRSMigrateAge" $SDRSMigrateAge
 
-if (-not $MigrationQuery1) 
-{
-   if ($DRSMigrateAge -eq $SDRSMigrateAge)
-   {
-      $MigrationQuery1 = Get-VIEventPlus -Start ($Date).AddDays(-$DRSMigrateAge) -Type Info
-   }
-   else {
-      if ($VIVersion -ge 5) {
-         $MigrationQuery1 = Get-VIEventPlus -Start ($Date).AddDays(-$DRSMigrateAge) -Type Info
-         $MigrationQuery2 = Get-VIEventPlus -Start ($Date).AddDays(-$SDRSMigrateAge) -Type Info
-      }
-      else {
-         $MigrationQuery1 = Get-VIEventPlus -Start ($Date).AddDays(-$DRSMigrateAge) -Type Info
+if (-not $DRSMigrations) {
+   $DRSMigrations = Get-VIEventPlus -Start $Date.AddDays(-$DRSMigrateAge) -EventType 'DrsVmMigratedEvent' | Select-Object CreatedTime, FullFormattedMessage
+}
+if ($VIVersion -ge 5 -and -not $SDRSMigrations) {
+   $StorageDRSQuery = Get-VIEventPlus -Start $Date.AddDays(-$SDRSMigrateAge) -EventType 'com.vmware.vc.sdrs.StorageDrsStoragePlacementEvent'
+   $SDRSMigrations = ForEach ($Event in $StorageDRSQuery) {
+      New-Object -TypeName PSObject -Property @{
+         'CreatedTime' = $Event.CreatedTime
+         'FullFormattedMessage' = "SDRS migrated $($Event.Arguments.Value[0]) to $($Event.Arguments.Value[2]) in datastore cluster $($Event.ObjectName)."
       }
    }
 }
 
-$DRSMigrations = @($MigrationQuery1 | Where-Object {$_.Gettype().Name -eq "DrsVmMigratedEvent"} | Select-Object createdTime, fullFormattedMessage)
-$SDRSMigrations = @($MigrationQuery2 | Where-Object {$_.FullFormattedMessage -imatch "(Storage vMotion){1}.*(DRS){1}"} | Select-Object createdTime, fullFormattedMessage)
-
 $DRSMigrations
 $SDRSMigrations
-
 
 if ($VIVersion -ge 5) {
     $HeaderText = "DRS Migrations (Last $DRSMigrateAge Day(s)) : $(@($DRSMigrations).count); SDRS Migrations (Last $SDRSMigrateAge Day(s)) : $(@($SDRSMigrations).count)"
@@ -52,3 +44,4 @@ $Header = $HeaderText
 # Changelog
 ## 1.2 : Removed setting $DRSMigrateAge since already specified in Plugin 01. Also added Storage DRS info
 ## 1.3 : Added $MigrationQuery# section in case General Info plugin is disabled. Issue #285
+## 1.4 : Changed DRS and SDRS Event Log Queries to be more efficient. Issue #695


### PR DESCRIPTION
Optimized DRS and SDRS queries in 01 General Info and 17 DRS Migrations (Issue #695).
This brought my vCheck runtime from 103.56 minutes to 44.64 minutes in a vSphere 7.0U3 environment.
General Information runtime from 2111.82 seconds to 13 seconds.
DRS & SDRS Migrations runtime from 1009.88 seconds to <1 second.

Optimized Get-VIEventPlus by swapping from an array to a list for faster inserts. Also added EventCategory parameter as mentioned in Issue #705 along with fixing 23 VI Events to use the EventCategory parameter.

I tested these changes on a vSphere 7.0U3 environment with 59 hosts and 962 VMs.