### PR TITLE
Fix errors with -Config when plugin has no question prompts or indentation

### DIFF
--- a/Plugins/60 VM/49 EVC Mismatch.ps1
+++ b/Plugins/60 VM/49 EVC Mismatch.ps1
@@ -1,4 +1,5 @@
 # Start of Settings
+# List of VMs for which the EVC mode does not match the Host/Cluster, do not report on any VMs who are defined here
 $ExcludeVMs = "Guest Introspection|ExcludeMe"
 # End of Settings
 

--- a/Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1
+++ b/Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1
@@ -19,6 +19,7 @@ $PluginVersion = 1.6
 $PluginCategory = "vSphere"
 
 # Start of Settings
+# Do not report uncontrolled snapshots on VMs that are defined here
 $ExcludeDS = "ExcludeMe"
 # End of Settings
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses errors in the vCheck.ps1 script related to handling plugins without question prompts and proper indentation. It also includes enhancements to the settings processing logic and updates to documentation comments in specific plugin scripts.

- **Bug Fixes**:
    - Fixed error handling in the Get-ID-String function to correctly parse ID names.
    - Resolved issues in the Invoke-Settings function to handle plugins without question prompts and correct indentation.
- **Enhancements**:
    - Improved the logic in the Invoke-Settings function to handle settings without question prompts and maintain proper formatting.
- **Documentation**:
    - Added comments in Plugins/60 VM/49 EVC Mismatch.ps1 and Plugins/60 VM/79 Find VMs in Uncontrolled Snapshot Mode.ps1 to clarify the purpose of settings.

<!-- Generated by sourcery-ai[bot]: end summary -->