### PR TITLE
Fix path separator for Linux with attachments

### DIFF
--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -880,8 +880,7 @@ if ($SetupSetting -or $config -or $GUIConfig) {
 
 		# Set the output filename 
 		if (-not (Test-Path -PathType Container $Outputpath)) { New-Item $Outputpath -type directory | Out-Null }
-		if ($IsWindows) { $pathSeparator = "\" } else { $pathSeparator = "/" }
-		$Filename = ("{0}{1}{2}_vCheck-Config_{3}.html" -f $Outputpath, $pathSeparator, $Server, (Get-Date -Format "yyyyMMdd_HHmm"))
+		$Filename = ("{0}{1}{2}_vCheck-Config_{3}.html" -f $Outputpath, [System.IO.Path]::DirectorySeparatorChar, $Server, (Get-Date -Format "yyyyMMdd_HHmm"))
 
 		#$configHTML = "<table>"
 		#$configHTML += Invoke-HTMLSettings -Filename $GlobalVariables

--- a/vCheck.ps1
+++ b/vCheck.ps1
@@ -880,7 +880,8 @@ if ($SetupSetting -or $config -or $GUIConfig) {
 
 		# Set the output filename 
 		if (-not (Test-Path -PathType Container $Outputpath)) { New-Item $Outputpath -type directory | Out-Null }
-		$Filename = ("{0}\{1}_vCheck-Config_{2}.html" -f $Outputpath, $Server, (Get-Date -Format "yyyyMMdd_HHmm"))
+		if ($IsWindows) { $pathSeparator = "\" } else { $pathSeparator = "/" }
+		$Filename = ("{0}{1}{2}_vCheck-Config_{3}.html" -f $Outputpath, $pathSeparator, $Server, (Get-Date -Format "yyyyMMdd_HHmm"))
 
 		#$configHTML = "<table>"
 		#$configHTML += Invoke-HTMLSettings -Filename $GlobalVariables


### PR DESCRIPTION
I noticed on Linux the email report would work until you set it to be an attachment. It was then failing using a backslash as the file path separator. This sets it to backslash if Windows and forward slash otherwise.

## Summary by Sourcery

Bug Fixes:
- Fix path separator issue for email attachments on Linux by using forward slash instead of backslash.