### PR TITLE
Get-VIEventPlus taking a long time on vCenter 8.0u3 and later

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -420,7 +420,7 @@ function Get-VIEventPlus {
    )
 
    process {
-      $eventnumber = 100
+      $eventnumber = 1000  # Increase the number of events retrieved per call
       $events = New-Object System.Collections.Generic.List[PSObject]
       $eventMgr = Get-View EventManager
       $eventFilter = New-Object VMware.Vim.EventFilterSpec
@@ -469,6 +469,7 @@ function Get-VIEventPlus {
                 }
                 $events.add($Item)
             }
+            $eventsBuffer = $eventCollector.ReadNextEvents($eventnumber)  # Continue reading events
          }
          $eventCollector.DestroyCollector()
       }


### PR DESCRIPTION
Issue was reported in https://github.com/alanrenouf/vCheck-vSphere/issues/766

I was able to reproduce the issue in an 8.0u3 lab using PowerCLI 13.3

Running the vCheck script with Trace set to 1 showed the Get-VIEventPlus going into a long loop to add events to a list checking through each event 1 by 1.
https://github.com/alanrenouf/vCheck-vSphere/blob/e248cf255757fb635051798096baa352907c4691/Plugins/00%20Initialize/00%20Connection%20Plugin%20for%20vCenter.ps1#L465-L472

I added code to retrieve more events at a time, and process them in larger batches

```
DEBUG:   24+     >>>> $DRSMigrations = Get-VIEventPlus -Start $Date.AddDays(-$DRSMigrateAge) -EventType 'DrsVmMigratedEvent' | Select-Object CreatedTime, FullFormattedMessage
...
DEBUG:  464+           >>>> $eventsBuffer = $eventCollector.ReadNextEvents($eventnumber)
DEBUG:  465+          while( >>>> $eventsBuffer){
DEBUG:  466+             ForEach ($Item in  >>>> $eventsBuffer) {
DEBUG:  466+             ForEach ( >>>> $Item in $eventsBuffer) {
DEBUG:  467+                 if ( >>>> -not $UseUTC) {
DEBUG:  468+                      >>>> $Item.CreatedTime = $Item.CreatedTime.ToLocalTime()
DEBUG:  470+                  >>>> $events.add($Item)
DEBUG:  466+             ForEach ( >>>> $Item in $eventsBuffer) {
DEBUG:  467+                 if ( >>>> -not $UseUTC) {
DEBUG:  468+                      >>>> $Item.CreatedTime = $Item.CreatedTime.ToLocalTime()
DEBUG:  470+                  >>>> $events.add($Item)
```

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where Get-VIEventPlus takes a long time to run on vCenter 8.0u3 and later due to inefficient event retrieval.